### PR TITLE
Added UG link to about and next steps modules

### DIFF
--- a/docs/topics/modules/about.adoc
+++ b/docs/topics/modules/about.adoc
@@ -2,3 +2,5 @@
 = About this document
 
 The purpose of this End to End document is to guide users who are new to {osio} through a series of simple scenarios. These scenarios are designed to use the major {osio} features. As a result, following the instructions in this document is the fastest way for users to learn how to set up simple applications using {osio} within an hour.
+
+See the link:https://docs.openshift.io/user_guide.html[{osio} User Guide] for comprehensive information about {osio} and its features.

--- a/docs/topics/modules/about.adoc
+++ b/docs/topics/modules/about.adoc
@@ -3,4 +3,4 @@
 
 The purpose of this End to End document is to guide users who are new to {osio} through a series of simple scenarios. These scenarios are designed to use the major {osio} features. As a result, following the instructions in this document is the fastest way for users to learn how to set up simple applications using {osio} within an hour.
 
-See the link:https://docs.openshift.io/user_guide.html[{osio} User Guide] for comprehensive information about {osio} and its features.
+See the link:user_guide.html[{osio} User Guide] for comprehensive information about {osio} and its features.

--- a/docs/topics/modules/next_steps.adoc
+++ b/docs/topics/modules/next_steps.adoc
@@ -14,4 +14,4 @@ If you followed the instructions in this document, you have now learned about {o
 * Debug your code using the Che workspace. See <<debugging_che_workspace>> for instructions.
 * Clean up your {osio} account so you can start afresh. See <<cleaning_up_oso_account>> for instructions.
 
-You can now try using what you have learned about {osio} with your own projects. See the link:https://docs.openshift.io/user_guide.html[{osio} User Guide] for comprehensive information about {osio} and its features. {osio} is currently Early Access only (see <<early-access-program>> for details). If you have any questions or suggestions for improvement with {osio} or this document, let us know using one of the methods listed in <<getting-support>>.
+You can now try using what you have learned about {osio} with your own projects. See the link:user_guide.html[{osio} User Guide] for comprehensive information about {osio} and its features. {osio} is currently Early Access only (see <<early-access-program>> for details). If you have any questions or suggestions for improvement with {osio} or this document, let us know using one of the methods listed in <<getting-support>>.

--- a/docs/topics/modules/next_steps.adoc
+++ b/docs/topics/modules/next_steps.adoc
@@ -14,4 +14,4 @@ If you followed the instructions in this document, you have now learned about {o
 * Debug your code using the Che workspace. See <<debugging_che_workspace>> for instructions.
 * Clean up your {osio} account so you can start afresh. See <<cleaning_up_oso_account>> for instructions.
 
-You can now try using what you have learned about {osio} with your own projects. {osio} is currently Early Access only (see <<early-access-program>> for details). If you have any questions or suggestions for improvement with {osio} or this document, let us know using one of the methods listed in <<getting-support>>.
+You can now try using what you have learned about {osio} with your own projects. See the link:https://docs.openshift.io/user_guide.html[{osio} User Guide] for comprehensive information about {osio} and its features. {osio} is currently Early Access only (see <<early-access-program>> for details). If you have any questions or suggestions for improvement with {osio} or this document, let us know using one of the methods listed in <<getting-support>>.


### PR DESCRIPTION
Added link to about and next steps.

link = what I think the link would be, i.e. https://docs.openshift.io/user_guide.html