### PR TITLE
Getting rid of 'Collab. Spaces' in favor of 'spaces'.

### DIFF
--- a/docs/topics/modules/about_areas.adoc
+++ b/docs/topics/modules/about_areas.adoc
@@ -1,8 +1,8 @@
 [id="about_areas"]
-= About Areas
+= About areas
 
-*Areas* can organize related <<about_work_items,Work Items>> into groups to distinguish between different types or functionalities that are worked on within a <<about_collaboration_spaces,Collaboration Space>>.
+*Areas* can organize related <<about_work_items,Work Items>> into groups to distinguish between different types or functionalities that are worked on within a <<about_collaboration_spaces,space>>.
 
-A Space can also include Areas. As an example, your Collaboration Space represents your software project, and each Area tracks components attached to the Space.
+A space can also include areas. As an example, your space represents your software project, and each area tracks components attached to the space.
 
-Each Area can have child Areas which represent the sub-components for your software project.
+Each area can have child areas which represent the sub-components for your software project.

--- a/docs/topics/modules/about_collaboration_spaces.adoc
+++ b/docs/topics/modules/about_collaboration_spaces.adoc
@@ -1,4 +1,4 @@
-[id="about_collaboration_spaces"]
-= About Collaboration Spaces
+[id="about_spaces"]
+= About spaces
 
-Collaboration Spaces are the equivalent of projects. Each <<about_iterations,Iteration>> and <<about_work_items,Work Item>> must be attached to a Space, and a team of users can be assigned to a project (Space) for the appropriate roles. By default, a Space contains one or more <<about_areas,Areas>> and Iterations.
+Spaces are the equivalent of projects. Each <<about_iterations,Iteration>> and <<about_work_items,Work Item>> must be attached to a space, and a team of users can be assigned to a project (space) for the appropriate roles. By default, a space contains one or more <<about_areas,Areas>> and Iterations.

--- a/docs/topics/modules/about_collaborators.adoc
+++ b/docs/topics/modules/about_collaborators.adoc
@@ -1,4 +1,4 @@
 [id="about_collaborators"]
 = About Collaborators
 
-*Collaborators* are members assigned to particular <<about_work_items,Work Items>> within a <<about_collaboration_spaces,Collaboration Space>>. They are assigned tasks for the development project which are tracked using Work Items. You can add Collaborators to your Space and then assign the relevant Work Items to them.
+*Collaborators* are members assigned to particular <<about_work_items,Work Items>> within a <<about_collaboration_spaces,space>>. They are assigned tasks for the development project which are tracked using Work Items. You can add Collaborators to your space and then assign the relevant Work Items to them.

--- a/docs/topics/modules/about_spaces.adoc
+++ b/docs/topics/modules/about_spaces.adoc
@@ -1,4 +1,4 @@
 [id="about_spaces"]
 = About spaces
 
-Spaces are the equivalent of projects. Each <<about_iterations,Iteration>> and <<about_work_items,Work Item>> must be attached to a Space, and a team of users can be assigned to a Space for the appropriate roles. By default, a Space contains one or more <<about_areas,Areas>> and Iterations.
+Spaces are the equivalent of projects. Each <<about_iterations,Iteration>> and <<about_work_items,Work Item>> must be attached to a space, and a team of users can be assigned to a space for the appropriate roles. By default, a space contains one or more <<about_areas,Areas>> and Iterations.

--- a/docs/topics/modules/about_work_items.adoc
+++ b/docs/topics/modules/about_work_items.adoc
@@ -1,10 +1,10 @@
 [id="about_work_items"]
 = About Work Items
 
-_Work Items_ (WI) are trackable and measurable units of work within a <<about_collaboration_spaces,Collaboration Space>>. They are captured representations of work, and can be modified based on the requirements of the development project.
+_Work Items_ (WI) are trackable and measurable units of work within a <<about_spaces,space>>. They are captured representations of work, and can be modified based on the requirements of the development project.
 
-Users can create and manage Work Items within a Collaboration Space using the *Planner*. Work Items track data such as ideas, user stories, bugs, and tasks. Work Items can be grouped and categorized into <<about_areas,Areas>> and <<about_iterations,Iterations>> to track progress and plan work.
+Users can create and manage Work Items within a space using the *Planner*. Work Items track data such as ideas, user stories, bugs, and tasks. Work Items can be grouped and categorized into <<about_areas,Areas>> and <<about_iterations,Iterations>> to track progress and plan work.
 
 Work Items are assigned to users and their status is changed to indicate the progress of the Work Item. Link Work Items to each other based on their relationships, enabling users to plan the scope of work better. For example, you can link Work Item A as the parent of Work Item B, enabling you to prioritize and order your work.
 
-The *Planner* includes a set of predefined templates based on common planning methodologies such as _Scrum_, _Agile_, and _Scenario Driven Development_. These templates determine the structure and features of the included Work Item types and states that are available for a Collaboration Space.
+The *Planner* includes a set of predefined templates based on common planning methodologies such as _Scrum_, _Agile_, and _Scenario Driven Development_. These templates determine the structure and features of the included Work Item types and states that are available for a space.

--- a/docs/topics/modules/adding_collaborators.adoc
+++ b/docs/topics/modules/adding_collaborators.adoc
@@ -1,19 +1,19 @@
 [id="adding_collaborators"]
 = Adding Collaborators
 
-You can add users as Collaborators to a Space and then assign Work Items to each person.
+You can add users as Collaborators to a space and then assign Work Items to each person.
 
 .Prerequisites
 
-* <<creating_a_new_space,Create a new Collaboration Space>> or select an existing Collaboration Space.
+* <<creating_a_new_space,Create a new space>> or select an existing space.
 * Ensure that the target user has an {osio} account.
 
 .Procedure
 
-. From your {osio} dashboard, click the name of a Space to view its dashboard.
+. From your {osio} dashboard, click the name of a space to view its dashboard.
 . Click the btn:[Equalizer] button (image:equalizer.png[title="Settings"]) at the top of the screen.
 . Click btn:[Collaborators].
 . Click the blue plus (*+*) icon in the top right corner. The *Add collaborators* dialog box displays.
 .. Click btn:[Select] and type a name in the text box to search for a user.
-.. From the displayed results, select the name of one or multiple users to add as Collaborators for your Space.
+.. From the displayed results, select the name of one or multiple users to add as Collaborators for your space.
 .. Click *Add* to add the selected users as collaborators.

--- a/docs/topics/modules/approving_build_pipeline.adoc
+++ b/docs/topics/modules/approving_build_pipeline.adoc
@@ -7,7 +7,7 @@ The build pipeline includes steps for a `Stage` build and a `Run` build. `Stage`
 
 To stage your application and review on `Stage`:
 
-. From your Space's dashboard, click btn:[Create] from the options at the top of the screen.
+. From your dashboard of your space, click btn:[Create] from the options at the top of the screen.
 . Click btn:[Pipelines].
 . Click the icon (image:rollout_icon.png[title="Rollout"]) next to `Rollout to Stage` in the displayed pipeline. OpenShift Online provides this public URL to access the staged Quickstart application. The Vert.x HTTP Booster Quickstart produces a simple API behind a REST endpoint over HTTP with a minimalist user interface.
 +

--- a/docs/topics/modules/assigning_a_collaborator.adoc
+++ b/docs/topics/modules/assigning_a_collaborator.adoc
@@ -1,13 +1,13 @@
 [id="assigning_a_collaborator"]
-= Assigning a Collaborator
+= Assigning a collaborator
 
-After adding Collaborators to your Space, you can assign <<about_work_items,Work Items>> to them:
+After adding Collaborators to your space, you can assign <<about_work_items,Work Items>> to them:
 
 .Prerequisites
 
-* Ensure that the user is <<adding_collaborators,added as a Collaborator>> to your Space.
+* Ensure that the user is <<adding_collaborators,added as a Collaborator>> to your space.
 
 .Procedure
-. Click the *Plan* tab to view a list of Work Items for your Space.
+. Click the *Plan* tab to view a list of Work Items for your space.
 . Double-click a Work Item to view its details.
-. Click the *Assignee* text box for a drop-down search window. Type the name of a Collaborator in your Space to assign them to this Work Item.
+. Click the *Assignee* text box for a drop-down search window. Type the name of a Collaborator in your space to assign them to this Work Item.

--- a/docs/topics/modules/assigning_an_area.adoc
+++ b/docs/topics/modules/assigning_an_area.adoc
@@ -4,11 +4,11 @@
 You can group Work Items by type or functionality by assigning relevant Areas to the Work Items as follows:
 
 .Prerequisites
-* Ensure that the user is <<adding_collaborators,added as a Collaborator>> to your Space.
-* Ensure that you have <<creating_a_new_work_item, created a Work Item>> for the Space.
+* Ensure that the user is <<adding_collaborators,added as a collaborator>> to your space.
+* Ensure that you have <<creating_a_new_work_item, created a Work Item>> for the space.
 
 .Procedure
-. Click the btn:[Plan] tab to view a list of Work Items for your Space.
+. Click the btn:[Plan] tab to view a list of Work Items for your space.
 . Double-click a Work Item to view its details.
 . Click the *Area* field to view a list of Areas to assign to the space. By default, your Root Area is assigned to a new Work Item.
 . Select one of the existing Areas to assign to your Work Item.

--- a/docs/topics/modules/associating_work_items_with_an_iteration.adoc
+++ b/docs/topics/modules/associating_work_items_with_an_iteration.adoc
@@ -3,7 +3,7 @@
 
 To associate a Work Item with an Iteration:
 
-. Click btn:[Plan] to see the Planner for your Space.
+. Click btn:[Plan] to see the Planner for your space.
 
 . Click the icon (image:kabob_white.png[title="Options"]) adjoining the Work Item.
 

--- a/docs/topics/modules/configuring_a_codebase.adoc
+++ b/docs/topics/modules/configuring_a_codebase.adoc
@@ -1,11 +1,11 @@
 [id="configuring_a_codebase"]
 = Configuring a codebase
 
-After creating a Space, you can add a codebase from GitHub and set up a pipeline to build the code.
+After creating a space, you can add a codebase from GitHub and set up a pipeline to build the code.
 
 .Prerequisites
 
-* Create a Space. See <<creating_a_new_space>> for instructions.
+* Create a space. See <<creating_a_new_space>> for instructions.
 
 .Procedure
 
@@ -13,7 +13,7 @@ After creating a Space, you can add a codebase from GitHub and set up a pipeline
 
 . The *Codebases* section displays the following options:
 
- * If you already have codebases in your Space, they are listed and you can use the btn:[+] icon at the upper-right of the section to import more codebases.
+ * If you already have codebases in your space, they are listed and you can use the btn:[+] icon at the upper-right of the section to import more codebases.
 
  * If there are no codebases in your space, you can:
 

--- a/docs/topics/modules/configuring_pipelines.adoc
+++ b/docs/topics/modules/configuring_pipelines.adoc
@@ -9,7 +9,7 @@ Advanced users can change the settings for their project pipeline builds in Open
 
 .Procedure
 
-. Navigate to your Space dashboard.
+. Navigate to your space dashboard.
 . Click btn:[Create].
 . Click btn:[Pipelines]. The `Pipelines` page lists all the pipeline builds for your project.
 . Click btn:[Edit Pipeline] for the target pipeline build.

--- a/docs/topics/modules/creating_a_new_area.adoc
+++ b/docs/topics/modules/creating_a_new_area.adoc
@@ -1,15 +1,15 @@
 [id="creating_a_new_area"]
 = Creating a New Area
 
-You can create a new child Area to group together related Work Items by type or functionality. When you create a new Collaboration Space, {osio} automatically creates a root Area with the same name. Each additional Area within the Collaboration Space is created as a child of the root Area or another existing Area in the Space.
+You can create a new child Area to group together related Work Items by type or functionality. When you create a new space, {osio} automatically creates a root Area with the same name. Each additional Area within the space is created as a child of the root Area or another existing Area in the space.
 
 .Prerequisites
 
-* Ensure you have <<creating_a_new_space,created a Collaboration Space>> to use.
+* Ensure you have <<creating_a_new_space,created a space>> to use.
 
 .Procedure
 
-. At the top of the page, click the *Equalizer* button (image:equalizer.png[title="Settings"]) to display a list of Areas in your Space.
+. At the top of the page, click the *Equalizer* button (image:equalizer.png[title="Settings"]) to display a list of Areas in your space.
 . In the top right corner of the `Areas` view, click btn:[+ Add Areas].
 . In the `Add New Area` dialog box, add a name for your new Area and a parent Area.
 . Click btn:[Create] to create the new child area.

--- a/docs/topics/modules/creating_a_new_iteration.adoc
+++ b/docs/topics/modules/creating_a_new_iteration.adoc
@@ -1,11 +1,11 @@
 [id="creating_a_new_iteration"]
-= Creating a New Iteration
+= Creating a new iteration
 
-Add Iterations to your Collaboration Space to plan and organize your Work Items. Click btn:[Plan] to view and modify existing Iterations and to add new Iterations.
+Add iterations to your space to plan and organize your Work Items. Click btn:[Plan] to view and modify existing Iterations and to add new Iterations.
 
 .Prerequisites
 
-* Ensure you have <<creating_a_new_space,created a Collaboration Space>>.
+* Ensure you have <<creating_a_new_space,created a space>>.
 
 .Procedure
 

--- a/docs/topics/modules/creating_a_new_pipeline.adoc
+++ b/docs/topics/modules/creating_a_new_pipeline.adoc
@@ -1,15 +1,15 @@
 [id="creating_a_new_pipeline"]
-= Creating a New Pipeline
+= Creating a new pipeline
 
-To create a new pipeline for your Collaboration Space, you must add a new project to the Space. {osio} includes templates to add new projects to your Space.
+To create a new pipeline for your space, you must add a new project to the space. {osio} includes templates to add new projects to your space.
 
 .Prerequisites
 
-* Ensure that you have created a Collaboration Space to use for the pipeline. See <<creating_a_new_space>> for instructions.
+* Ensure that you have created a space to use for the pipeline. See <<creating_a_new_space>> for instructions.
 
 .Procedure
 
-. Click the name of a Space to view the dashboard.
+. Click the name of a space to view the dashboard.
 
 . Click btn:[Add to space]. The `How would you like to get started?` menu appears for your new space.
 +
@@ -25,7 +25,7 @@ image::get_started_menu.png[How would you like to get started menu]
 
 . Select a build pipeline strategy. For this example, use the default value (`Release, Stage, Approve and Promote`) and click btn:[Next].
 
-. The `Build configuration` screen displays the details for your `Jenkins Space` and options for web hooks and triggering builds. Use the default options for these fields and click btn:[Finish].
+. The `Build configuration` screen displays the details for your `Jenkins space` and options for web hooks and triggering builds. Use the default options for these fields and click btn:[Finish].
 
 You have now added a Quickstart project to your space, which initiates a build pipeline for your new project. At this stage, {osio} also adds your project pipeline into your OpenShift Online account and creates a new GitHub repository for your project.
 

--- a/docs/topics/modules/creating_a_new_quickstart_project.adoc
+++ b/docs/topics/modules/creating_a_new_quickstart_project.adoc
@@ -11,6 +11,6 @@ Use the {osio} Quickstart project wizard to create a new project from the availa
 . Click btn:[Next].
 . In the *Configure Pipeline* section, select a build pipeline strategy. The default value *Release, Stage, Approve and Promote* is suitable for most use cases.
 . Click btn:[Next].
-. The *Build configuration* section displays the name of your *Jenkins Space* and options to *Trigger build* and *Add continuous integration web hooks* when your application is deployed.
+. The *Build configuration* section displays the name of your *Jenkins space* and options to *Trigger build* and *Add continuous integration web hooks* when your application is deployed.
 Use the default options for these fields and click btn:[Finish].
 . The *Summary* section displays your selected options for the Application. Click btn:[Ok] to continue.

--- a/docs/topics/modules/creating_a_new_space.adoc
+++ b/docs/topics/modules/creating_a_new_space.adoc
@@ -1,7 +1,7 @@
 [id="creating_a_new_space"]
 = Creating a new space
 
-To start working with a new project, create a new Space. Each Space includes a team of users in assigned roles as well as unique <<about_work_items,Work Items>> and <<about_iterations,Iterations>> used to manage the new project.
+To start working with a new project, create a new space. Each space includes a team of users in assigned roles as well as unique <<about_work_items,Work Items>> and <<about_iterations,Iterations>> used to manage the new project.
 
 .Prerequisites
 
@@ -11,8 +11,8 @@ To start working with a new project, create a new Space. Each Space includes a t
 
 . On your {osio-link} home page, click your user name in the upper-left corner of the screen.
 . Select *Create space* from the drop-down menu.
-. In the *Name* field, add a unique name for the new Space.
-. From the *Template* drop-down list, select *Scenario Driven Planning*. This template creates Spaces based on Scenarios, which are real-world problems from the user's point of view. The Scenarios deliver Value Propositions and are realized through (user) Experiences.
+. In the *Name* field, add a unique name for the new space.
+. From the *Template* drop-down list, select *Scenario Driven Planning*. This template creates spaces based on Scenarios, which are real-world problems from the user's point of view. The Scenarios deliver Value Propositions and are realized through (user) Experiences.
 //. Select a *Template* type from the drop-down menu. The available options are:
 //.. *Agile* - Your space is centered around Agile-based planning.
 //.. *Scrum* - Your space includes an iterative and incremental Agile-based development framework. This option is similar to the **Agile** option but with more specific planning and development tracking.
@@ -25,6 +25,6 @@ To start working with a new project, create a new Space. Each Space includes a t
 
 * *<<creating_a_new_quickstart_project,Create a new Quickstart project>>*: Use wizards to automatically set up your development environment and quickly create projects by using the desired tools.
 
-* btn:[No thanks, take me to the new space dashboard]: Go to your new Space dashboard to begin working in the space.
+* btn:[No thanks, take me to the new space dashboard]: Go to your new space dashboard to begin working in the space.
 +
-image::new_space_dialog.png[New Space Dialog Box]
+image::new_space_dialog.png[New space dialog box]

--- a/docs/topics/modules/creating_a_new_work_item.adoc
+++ b/docs/topics/modules/creating_a_new_work_item.adoc
@@ -1,11 +1,11 @@
 [id="creating_a_new_work_item"]
-= Creating a New Work Item
+= Creating a new Work Item
 
-You can add <<about_work_items,Work Items>> to your Collaboration Space in one of several ways.
+You can add <<about_work_items,Work Items>> to your space in one of several ways.
 
 .Prerequisites
 
-* <<creating_a_new_space,Create a new Collaboration Space>> or select an existing Collaboration Space.
+* <<creating_a_new_space,Create a new space>> or select an existing space.
 
 include::quick_add_work_item.adoc[leveloffset=+1]
 

--- a/docs/topics/modules/creating_new_project.adoc
+++ b/docs/topics/modules/creating_new_project.adoc
@@ -3,12 +3,12 @@
 
 // for hello-world
 ifeval::["{context}" == "hello-world"]
-When you create a new Space, the `How would you like to get started?` dialog box opens. Use this menu to create a new Quickstart project as follows:
+When you create a new space, the `How would you like to get started?` dialog box opens. Use this menu to create a new Quickstart project as follows:
 endif::[]
 
 // for spring-boot
 ifeval::["{context}" == "spring-boot"]
-You will now learn how to create a second quickstart project in your Space. The Hello World project was a Vert.X application and the second quickstart is a Spring Boot application.
+You will now learn how to create a second quickstart project in your space. The Hello World project was a Vert.X application and the second quickstart is a Spring Boot application.
 
 . In your {osio} home page, double-click your new space.
 . In the dashboard of your space, click btn:[Add to space]. The `How would you like to get started?` dialog box opens.
@@ -43,17 +43,17 @@ endif::[]
 NOTE: Pipelines allow developers to create a repeatable, reliable, and incrementally improving process to move the software from code to the execution environment.
 +
 
-.. The `Build Config` screen displays the details for your `Jenkins Space` and options for adding continuous integration hooks and triggering a build when your application is deployed. Use the default options for these fields and click btn:[Finish].
+.. The `Build Config` screen displays the details for your `Jenkins space` and options for adding continuous integration hooks and triggering a build when your application is deployed. Use the default options for these fields and click btn:[Finish].
 .. The `Summary` screen displays your selected options. Click btn:[Ok] to continue.
 
 // for hello-world
 ifeval::["{context}" == "hello-world"]
-Your new Vert.X project is now created in your Space.
+Your new Vert.X project is now created in your space.
 endif::[]
 
 // for spring-boot
 ifeval::["{context}" == "spring-boot"]
-Your new Spring Boot project is now created in your Space.
+Your new Spring Boot project is now created in your space.
 endif::[]
 
 // end conditionals

--- a/docs/topics/modules/creating_new_space.adoc
+++ b/docs/topics/modules/creating_new_space.adoc
@@ -1,12 +1,12 @@
 [id="creating_new_space-{context}"]
 = Creating a new space
 
-In {osio}, the first step for any new project is to create a new Space. You can then add users as Collaborators for the Space and all the work is tracked within the Space using Work Items. Each Space must have a unique name. Create a new space as follows:
+In {osio}, the first step for any new project is to create a new space. You can then add users as Collaborators for the space and all the work is tracked within the space using Work Items. Each space must have a unique name. Create a new space as follows:
 
 . In the {osio} home page, click btn:[Create a space].
 . In the dialog box, type *myspace* as the unique name for your space.
 +
-image::create_space.png[Create New Space]
+image::create_space.png[Create new space]
 +
-. Use the drop-down menu for the `Template` field to select a template for your new Space. For this example, select *Scenario Driven Planning* and click btn:[Create].
+. Use the drop-down menu for the `Template` field to select a template for your new space. For this example, select *Scenario Driven Planning* and click btn:[Create].
 . The `How would you like to get started?` menu is displayed for your new space. 

--- a/docs/topics/modules/creating_portfolio_level_work_items.adoc
+++ b/docs/topics/modules/creating_portfolio_level_work_items.adoc
@@ -5,7 +5,7 @@ The Product Management team envisages Scenarios, identifies Fundamental and Pape
 
 You can create Scenario, Fundamental, or Papercut type of Work Items and associated child Value Propositions and Experiences as follows:
 
-. Click btn:[Plan] at the top of the page to view the Planner. The default *Backlog* view with *All* the Work Items in the Space is displayed.
+. Click btn:[Plan] at the top of the page to view the Planner. The default *Backlog* view with *All* the Work Items in the space is displayed.
 . Click btn:[Portfolio], and then btn:[Create work item] from the pane at the bottom of the screen to create a new work item.
 +
 NOTE: You can create only Portfolio type work items such as Scenario, Fundamental, and Papercuts.

--- a/docs/topics/modules/creating_using_new_work_item.adoc
+++ b/docs/topics/modules/creating_using_new_work_item.adoc
@@ -1,7 +1,7 @@
 [id="creating_using_new_work_item"]
 = Creating and using a new work item
 
-After creating a project in your Space, create a Work Item and use it to track your changes to the project code.
+After creating a project in your space, create a Work Item and use it to track your changes to the project code.
 
 . On the top of the {osio} page, click `Plan`.
 . If you have not already activated the Experimental Features of {osio}, the `Experimental Features` warning appears. Check `I agree to the terms of this feature, as written above` and click btn:[Activate All Experimental Features] to proceed.

--- a/docs/topics/modules/deleting_a_space.adoc
+++ b/docs/topics/modules/deleting_a_space.adoc
@@ -1,11 +1,11 @@
 [id="deleting_existing_space"]
 = Deleting an existing space
 
-If an {osio} Space is no longer required, delete it as follows:
+If an {osio} space is no longer required, delete it as follows:
 
-WARNING: When deleted, the Space and all its contents (Work Items, Codebases, Workspaces, etc.) are also permanently deleted.
+WARNING: When deleted, the space and all its contents (Work Items, Codebases, Workspaces, etc.) are also permanently deleted.
 
 . On your {osio-link} home page, click your user name in the upper-left corner of the screen.
 . On the drop-down list, click  *View all spaces*.
 . Click the (image:delete.png [Delete]) icon, the *Remove Space* dialog box is displayed asking for confirmation.
-. Click btn:[Remove] to confirm and delete your Space.
+. Click btn:[Remove] to confirm and delete your space.

--- a/docs/topics/modules/glossary.adoc
+++ b/docs/topics/modules/glossary.adoc
@@ -3,11 +3,11 @@
 
 This glossary provides concise definitions of terms and explanations of concepts used in {rhosio} and in related documentation.
 
-Areas:: Use Areas to organize Work Items to distinguish between different types or functionalities that are being worked on within a Space.
+Areas:: Use Areas to organize Work Items to distinguish between different types or functionalities that are being worked on within a space.
 
 Backlog:: A Backlog is a list of Work Items that have not been triaged and assigned to a specific Iteration.
 
-Space:: A Space is the equivalent of a project. Each Iteration and Work Item must be attached to a Space, and a team of people can be attached to a Space in various roles. By default, a Space contains at least one Area and one Iteration.
+space:: A space is the equivalent of a project. Each Iteration and Work Item must be attached to a space, and a team of people can be attached to a space in various roles. By default, a space contains at least one Area and one Iteration.
 
 Iteration:: Iterations are used to organize Work Items for planning or implementation in a certain order. They are time bound and can be used to model Sprints when used with Scrum. Typically an Iteration comprises a mix of work items, ranging from Scenarios, Features, Papercuts, Experiences or Tasks, identified to be executed within the time frame of the Iteration.
 
@@ -15,7 +15,7 @@ Pipeline:: Pipelines are a continuous delivery system that, at each step, tests 
 
 Scenario-Driven Planning:: A software development methodology focused on real-world problems, or Scenarios, described in the language and from the viewpoint of the user. Scenarios deliver particular Value Propositions and are realized through Experiences.
 
-Work Item:: Work Items describe and keep track of work that needs to be completed. They can be assigned to collaborators within a Space. Each Work Item must be attached to a Space and an Area (assigned by default). This can be used to model bugs, tasks, features, ideas, and more.
+Work Item:: Work Items describe and keep track of work that needs to be completed. They can be assigned to collaborators within a space. Each Work Item must be attached to a space and an Area (assigned by default). This can be used to model bugs, tasks, features, ideas, and more.
 
 Usage Outliers:: Components of your software stack that are not commonly used in similar open source stacks or that rarely go together.
 

--- a/docs/topics/modules/importing_a_codebase.adoc
+++ b/docs/topics/modules/importing_a_codebase.adoc
@@ -4,10 +4,10 @@
 Use the *Import Codebase* option to manually add the details for your existing codebase into {osio}.
 
 . Click btn:[Import Codebase].
-. If required, in the *Space Path* field, change the path to your Space.
+. If required, in the *Space Path* field, change the path to your space.
 . In the *GitHub Repository* field, add the GitHub repository path.
 . Click btn:[Sync] to retrieve details for the repository. If the sync is successful, metadata for the added repository is displayed under the btn:[Sync] button.
-. Click btn:[Associate Repository to Space] to add the repository to your Space. The menu:Create[Codebases] sub-tab now displays your repository with information about when it was created and the last commit date.
+. Click btn:[Associate Repository to Space] to add the repository to your space. The menu:Create[Codebases] sub-tab now displays your repository with information about when it was created and the last commit date.
 . Click *Create workspace* for the target repository from the displayed list. A success message appears when the Workspace is successfully created in Eclipse Che.
 . When your Workspace is ready, in the drop-down list, select the new Workspace for your repository, and then click btn:[Open].
 +

--- a/docs/topics/modules/importing_existing_code.adoc
+++ b/docs/topics/modules/importing_existing_code.adoc
@@ -10,7 +10,7 @@ Use the {osio} *Application wizard* to import an existing project codebase into 
 .. Select a build pipeline strategy. The default value *Release, Stage, Approve and Promote* is suitable for most use cases.
 .. Ensure that the *Override Jenkins and POM files* option is selected
 . Click btn:[Next].
-. In the *Build configuration* section the *Jenkins Space* field displays the name of your Jenkins space.
+. In the *Build configuration* section the *Jenkins space* field displays the name of your Jenkins space.
 
 .. Select *Trigger build* to trigger a build once your Application is deployed.
 .. Select *Add continuous integration web hooks* to add continuous integration web hooks to your Application.

--- a/docs/topics/modules/importing_your_project.adoc
+++ b/docs/topics/modules/importing_your_project.adoc
@@ -1,7 +1,7 @@
 [id="importing_your_project"]
 = Importing your project
 
-After creating a Space, the `How would you like to get started?` menu appears. Access this menu later by clicking btn:[Add to space] in your Space dashboard.
+After creating a space, the `How would you like to get started?` menu appears. Access this menu later by clicking btn:[Add to space] in your space dashboard.
 
 . In the `How would you like to get started?` menu, click `Import existing code` 
 +

--- a/docs/topics/modules/next_steps.adoc
+++ b/docs/topics/modules/next_steps.adoc
@@ -3,8 +3,8 @@
 
 If you followed the instructions in this document, you have now learned about {osio} and its features. You are now able to:
 
-* Create Spaces for your projects. See <<creating_new_space-hello-world>> for instructions.
-* Add code from an existing project to your Space. See <<importing-existing-project>> for instructions.
+* Create spaces for your projects. See <<creating_new_space-hello-world>> for instructions.
+* Add code from an existing project to your space. See <<importing-existing-project>> for instructions.
 * Create new projects using the quickstart wizards and test them. See <<hello_world_developers>> for Vert.X project instructions and <<spring_boot_quickstart_tutorial>> for Spring Boot project instructions.
 * Create Work Items to track and manage your tasks. See <<creating_using_new_work_item>> for instructions.
 * Use the build pipelines to stage reviews in the `Stage` and `Run` environments. See <<working_with_pipelines>> for instructions.

--- a/docs/topics/modules/ordering_and_monitoring_work_items.adoc
+++ b/docs/topics/modules/ordering_and_monitoring_work_items.adoc
@@ -5,7 +5,7 @@ The `Backlog` displays a list view used to plan your work. You can order Work It
 
 The `Backlog` displays the list of Work Items as a list where all the Work Items display in a single file.
 
-Click btn:[Plan] to view the Planner. You can order the Work Items in your Space as follows:
+Click btn:[Plan] to view the Planner. You can order the Work Items in your space as follows:
 
 * In the btn:[Backlog] view, drag and drop a selected Work Item to reorder them. Alternatively, select btn:[Move to Top] or btn:[Move to Bottom] from the options (image:kabob_white.png[title="Options"]) menu.
 

--- a/docs/topics/modules/quick_add_work_item.adoc
+++ b/docs/topics/modules/quick_add_work_item.adoc
@@ -1,9 +1,9 @@
 [id="quick_add_work_item"]
 = Quick-Add a New Work Item
 
-You can use the quick-add method as an instant widget to add Work Items to your Collaboration Space:
+You can use the quick-add method as an instant widget to add Work Items to your space:
 
-. Click btn:[Plan] to view the `Planner` for your Space.
+. Click btn:[Plan] to view the `Planner` for your space.
 
 * Either use the default `Backlog` view:
 .. Click btn:[Create Work Item] at the bottom of the page.

--- a/docs/topics/modules/removing_iterations_from_work_item.adoc
+++ b/docs/topics/modules/removing_iterations_from_work_item.adoc
@@ -5,10 +5,10 @@ You can remove an Iteration from a Work Item without selecting a replacement. Th
 
 To move a Work Item to the Backlog:
 
-. Click btn:[Plan] to see the Planner for your Space.
+. Click btn:[Plan] to see the Planner for your space.
 
 . Click the icon (image:kabob_white.png[title="Options"]) adjoining the Work Item.
 
 . From the displayed options, select btn:[Move to Backlog].
 
-Select btn:[Backlog] to display all the Work Items within a Space.
+Select btn:[Backlog] to display all the Work Items within a space.

--- a/docs/topics/modules/selecting_an_iteration.adoc
+++ b/docs/topics/modules/selecting_an_iteration.adoc
@@ -4,7 +4,7 @@
 After logging in and selecting the appropriate space, click btn:[Plan] to view the Iterations for that space. Existing Iterations are grouped into one of the following categories:
 
 * _Active Iteration_ lists active Iterations.
-* _All Iterations_ displays a list of all Iterations in the Space. These include active and closed Iterations, as well as Iterations that have not yet started.
+* _All Iterations_ displays a list of all Iterations in the space. These include active and closed Iterations, as well as Iterations that have not yet started.
 
 Select an Iteration listed in one of these groups to display the included Work Items. See <<associating_work_items_with_an_iteration,Associating Work Items with an Iteration>> for more information.
 

--- a/docs/topics/modules/stopping_existing_workspaces.adoc
+++ b/docs/topics/modules/stopping_existing_workspaces.adoc
@@ -5,7 +5,7 @@ Before creating a workspace for your project, stop the workspace for your previo
 
 Review the workspaces in your OpenShift Online account as follows:
 
-. In your Space's dashboard, click btn:[Create].
+. In your the dashboard of your space, click btn:[Create].
 . In the `Codebases` view, click btn:[Open] for the older project's workspace. Allow several minutes for the project to load.
 +
 image::codebase_list.png[List of Codebases]

--- a/docs/topics/modules/using_backlog_to_create_work_item.adoc
+++ b/docs/topics/modules/using_backlog_to_create_work_item.adoc
@@ -1,7 +1,7 @@
 [id="using_backlog_to_create_work_item"]
 = Using the Backlog to Create a Work Item
 
-. Click btn:[Plan] in your Collaboration Space.
+. Click btn:[Plan] in your space.
 
 . Click btn:[Backlog] to view the Work Item backlog.
 

--- a/docs/topics/modules/using_board_to_create_work_items.adoc
+++ b/docs/topics/modules/using_board_to_create_work_items.adoc
@@ -1,7 +1,7 @@
 [id="using_board_to_create_work_items"]
 = Using the Board to Create a Work Item
 
-. Click btn:[Plan] to view the *Planner* for your Space.
+. Click btn:[Plan] to view the *Planner* for your space.
 
 . Click btn:[Board] to see the Planner's Board view.
 

--- a/docs/topics/modules/using_detailed_method_to_create_work_items.adoc
+++ b/docs/topics/modules/using_detailed_method_to_create_work_items.adoc
@@ -3,7 +3,7 @@
 
 The detailed method requires adding more details for the Work Item compared to the quick-add method, which only requires basic information to create the Work Item.
 
-. Click btn:[Analyze] to view the Space dashboard.
+. Click btn:[Analyze] to view the space dashboard.
 
 . In the `My Work Items` panel, click btn:[+].
 

--- a/docs/topics/modules/using_stack_reports.adoc
+++ b/docs/topics/modules/using_stack_reports.adoc
@@ -3,7 +3,7 @@
 
 {osio} includes a Stack Report feature that provides information about your stack components and recommends improvements for your application. The Stack Report is available after the first pipeline build completes.
 
-. Return to your Space dashboard in the {osio} browser tab.
+. Return to your space dashboard in the {osio} browser tab.
 . The `Stack Report Recommendations` panel in the dashboard shows a summary of the Stack Report.
 +
 image::stack_reports.png[Stack Reports]

--- a/docs/topics/modules/viewing_project_github.adoc
+++ b/docs/topics/modules/viewing_project_github.adoc
@@ -3,7 +3,7 @@
 
 After reviewing your pipeline build running in {osio} and OpenShift Online, view your project <<about_codebases,codebase>> in GitHub as follows:
 
-. Return to your Space dashboard.
+. Return to your space dashboard.
 . In the `Codebases` panel, click the GitHub link to the project code.
 +
 image::gh_link.png[GitHub Code Link]

--- a/docs/topics/modules/working_with_pipelines.adoc
+++ b/docs/topics/modules/working_with_pipelines.adoc
@@ -3,13 +3,13 @@
 
 When you create a new Quickstart project, a new build/pipeline execution initiates. In a build pipeline, <<about_stage_run,*Stage* and *Run*>> are individual OpenShift projects. `Stage` is a production staging area to review and test changes before they are finalized and then staged on `Run`.
 
-After you create a new Quickstart project, you can see the new project build pipeline running in the Space dashboard:
+After you create a new Quickstart project, you can see the new project build pipeline running in the space dashboard:
 
 image::pipeline_running.png[A Running Pipeline Build]
 
 To view your new Quickstart project pipeline:
 
-* Click btn:[Pipelines]. This page displays all running pipelines for your Space.
+* Click btn:[Pipelines]. This page displays all running pipelines for your space.
 
 Your new project build pipeline displays on this page at the `Approve` stage:
 


### PR DESCRIPTION
This partially fixes #71 -- removes all mentions of "Collaboration Space" and uses "space" instead.