### PR TITLE
Fixes relevant comments in #1842 in OSIO repo.

### DIFF
--- a/docs/topics/modules/analyze_che_dependencies.adoc
+++ b/docs/topics/modules/analyze_che_dependencies.adoc
@@ -28,4 +28,6 @@ The error indicates that the dependency analyzer has identified a high Common Vu
 
 . Update the version to `1.2.1`. The error icon disappears when the version number is updated.
 
-You have now learned how {OSIO} anaytics automatically analyzes dependencies in your code, identifies security vulnerabilities, and recommends fixes.
+. Commit these changes to add this dependency to your stack.
+
+You have now learned how {OSIO} analytics automatically analyzes dependencies in your code, identifies security vulnerabilities, and recommends fixes.

--- a/docs/topics/modules/configuring_your_che_workspace.adoc
+++ b/docs/topics/modules/configuring_your_che_workspace.adoc
@@ -25,7 +25,7 @@ endif::[]
 // end of conditions
 +
 .. In the *Project Configuration* window, select *Maven* and click btn:[Save].
-.. Click the *run* option from the Run button (image:tri_run.png[title="Run button"]). Maven then downloads the required dependencies, compiles the application, and starts the _verticle_ (Vert.x uses this name for deployed code). For Vert.x projects, this also sets up the server and hot deploy options.
+.. Click the *run* option from the Run button (image:tri_run.png[title="Run button"]). Maven then downloads the required dependencies, compiles the application, and starts the _verticle_ (Vert.x uses this name for deployed code). For Vert.x projects, this also sets up the server and hot deploy options. The hot deploy option automatically updates the application when you make a change.
 . A *run* terminal appears at the bottom pane of the Che workspace. When the `mvn{nbsp}build` command finishes executing, the *run* view displays the following message:
 +
 ----

--- a/docs/topics/modules/setting_up_debugger.adoc
+++ b/docs/topics/modules/setting_up_debugger.adoc
@@ -8,7 +8,7 @@ To debug your project code using the Che workspace Debugger feature:
 image::debug_button.png[Debugger Button]
 +
 
-. In the new *debug* tab, look for the following lines when the debugging starts:
+. In the new *debug* tab in the *Processes* pane at the bottom of the screen, look for the following lines when the debugging starts:
 +
 ----
 [INFO] The application will wait for a debugger to attach on debugPort 5005
@@ -25,8 +25,8 @@ image::edit_debug_config.png[Edit Debug Configuration]
 +
 
 . In the *Debug Configurations* dialog box:
-.. Click btn:[+] for the *JAVA* item in the dialog box to add a Remote Java port.
-.. Change the *Port* value to `5005`.
+.. In the left pane, click btn:[+] for the *JAVA* item in the dialog box to add a *Remote Java* port.
+.. In the right pane, change the *Port* value to `5005`.
 .. Click btn:[Save] and then btn:[Close].
 +
 image::debug_config.png[Debugger Configuration Dialog]
@@ -45,12 +45,11 @@ image::debug_config.png[Debugger Configuration Dialog]
 image::breakpoint.png[Create Breakpoint]
 +
 
-. Click the *Debug* option at the bottom of the workspace:
+. Click the *Debug* option at the bottom of the workspace to confirm the addition of the breakpoint:
 +
 image::debug_option.png[Debug Option]
 +
-
-. The *Breakpoints* pane at the lower left of the *Debug* section displays the added breakpoint:
+The *Breakpoints* pane at the lower left of the *Debug* section displays the added breakpoint:
 +
 image::debug_breakpoint.png[Breakpoint View]
 

--- a/docs/topics/modules/using_stack_reports.adoc
+++ b/docs/topics/modules/using_stack_reports.adoc
@@ -13,7 +13,7 @@ It highlights the security issues, usage outliers, and unknown or conflicting li
 === Detailed analysis of your stack components
 The detailed component analysis provides recommendations for relevant alternate components in case of license outliers (licenses not commonly used in similar stacks) and usage outliers (components not commonly used in similar stacks). It also recommends the appropriate versions for your stack components.
 
-It helps you assess the credibility of your stack components by providing usage statistics for your components such as number of {osio} projects using these components, GitHub statistics, GitHub projects dependent on these components, and tags associated with the components of your stack.
+It helps you assess the credibility of your stack components by providing usage statistics for your components, such as the number of {osio} projects using these components, GitHub statistics, GitHub projects dependent on these components, and tags associated with the components of your stack.
 
 To act on the alternate component recommendations, if any:
 

--- a/docs/topics/modules/using_stack_reports.adoc
+++ b/docs/topics/modules/using_stack_reports.adoc
@@ -11,36 +11,32 @@ The stack summary provides a synopsis of the analysis report.
 It highlights the security issues, usage outliers, and unknown or conflicting licenses in your stack. For more information about these concepts see the link:user_guide.html#glossary[Glossary].
 
 === Detailed analysis of your stack components
-The detailed component analysis provides recommendations for relevant alternate components in case of license outliers (that is, licenses not used in similar stacks) and usage outliers (that is, components not used in similar stacks). It also recommends the appropriate versions for your stack components.
+The detailed component analysis provides recommendations for relevant alternate components in case of license outliers (licenses not commonly used in similar stacks) and usage outliers (components not commonly used in similar stacks). It also recommends the appropriate versions for your stack components.
 
-It helps you assess the credibility of your stack components by providing various usage statistics for your components such as:
+It helps you assess the credibility of your stack components by providing usage statistics for your components such as number of {osio} projects using these components, GitHub statistics, GitHub projects dependent on these components, and tags associated with the components of your stack.
 
-* Number of {osio} projects using these components
-* GitHub statistics such as watchers and usage count
-* Other GitHub projects dependent on these components
-* Tags associated with the components of your stack
-
-To act on the alternate component recommendations:
+To act on the alternate component recommendations, if any:
 
 . In the *Detailed analysis of your stack components*, select *Alternate Components* from the filter to see the recommended alternate components.
 +
-image::filtered_alt_componet.png[Filtered Alternate Component]
+. Click *Create Work Item* adjacent to the recommended alternate component to add the component to your stack.
+
+=== Additional components recommended by {osio}
+
+{osio} recommends additional components suitable for your stack based on its analysis of similar open source stacks. These components are commonly used by similar stacks and augment your stack.
+
+The Additional components section has one recommendation to enhance the application.
+
+. Click *Additional components recommended by {osio}* to see the recommended component. It includes a link to create a new work item to track the addition of this component to your stack:
 +
-. Click *Create Work Item* adjacent to the recommended alternate component to add the component to your stack. {osio} automatically creates a new work item and displays the following success message:
+image::action_item.png[Create Work Item]
++
+. Click *Create work item* to create an auto populated work item for this recommendation. The following message displays when the work item is created:
 +
 image::wi_created.png[Work Item Created]
 +
 . Click *View Work Item* to view the auto populated work item in a new browser tab.
 +
 image::automatic_wi.png[Automatically Created Work Item]
-
-=== Additional components recommended by {osio}
-
-{osio} recommends additional components suitable for your stack based on its analysis of similar open source stacks. These components are commonly used by similar stacks and augment your stack.
-
-* Click *Create work item* adjacent to the recommended additional component to add the component to your stack.
-+
-image::action_item.png[Create Work Item]
-+
 
 You have now learned how to use stack reports to analyze and improve your application stack and track the required changes using work items.

--- a/docs/topics/modules/using_terminal_tab.adoc
+++ b/docs/topics/modules/using_terminal_tab.adoc
@@ -1,7 +1,7 @@
 [id="using_terminal_tab"]
 = Using the terminal tab
 
-. If your application is not running, click run at the top of the screen and wait for the *run* command to complete.
+. In your Che workspace, if your application is not running, click run at the top of the screen and wait for the *run* command to complete.
 +
 image::tri_run.png[Run Icon]
 +


### PR DESCRIPTION
Fixes comments in https://github.com/openshiftio/openshift.io/issues/1842 relevant to the getting started guide. Made the location of certain action items more clear based on the suggestions here.

Also reworked the Using stack reports section to match the workflow of the the vertx application and the rest of the sections in getting started.
Build and validate scripts and asciidoc test worked fine.