### PR TITLE
Added SDD Concepts to glossary

### DIFF
--- a/docs/topics/modules/api_get_component_analyses_response.adoc
+++ b/docs/topics/modules/api_get_component_analyses_response.adoc
@@ -198,7 +198,7 @@ curl -k -H "Authorization: Bearer <openshift.io authentication token>" https://<
     },
     "schema": {
         "name": "analyses_graphdb",
-        "url": "http://recommender.api.openshift.io/api/v1/schemas/api/analyses_graphdb/1-2-0/",
+        "url": "http://<recommender api url>/api/v1/schemas/api/analyses_graphdb/1-2-0/",
         "version": "1-2-0"
     }
 }

--- a/docs/topics/modules/api_get_stack_analyses_response.adoc
+++ b/docs/topics/modules/api_get_stack_analyses_response.adoc
@@ -514,7 +514,7 @@ curl -k -H "Authorization: Bearer <openshift.io authentication token>" https://<
 ----
 200:
 {
-    "error": "Analysis for request ID '510a314561104e8ba14bac489b31efe0' is in progress"
+    "error": "Analysis for request ID 'add9caf0a1ff47969a8f27a4241a0230' is in progress"
 }
 
 ----

--- a/docs/topics/modules/api_post_stack_analyses_request.adoc
+++ b/docs/topics/modules/api_post_stack_analyses_request.adoc
@@ -42,9 +42,9 @@ curl -k -H "Authorization: Bearer <openshift.io authentication token>" -F "manif
 ----
 
 {
-    "id": "510a314561104e8ba14bac489b31efe0",
+    "id": "add9caf0a1ff47969a8f27a4241a0230",
     "status": "success",
-    "submitted_at": "2017-07-18 08:04:49.165068"
+    "submitted_at": "2018-04-10 08:59:24.472832"
 }
 
 ----

--- a/docs/topics/modules/flat_view_of_work_items.adoc
+++ b/docs/topics/modules/flat_view_of_work_items.adoc
@@ -2,7 +2,7 @@
 = Flat view of work items
 The flat list view is useful to track your work items based on their work item type groups. Depending on the selection of the work item type groups in the left pane of the planner, it displays the *Scenarios*, *Experiences*, or *Requirements* for your space.
 
-It does not display the hierarchical parent-child links for the work items and focuses only on the selected work item type group. This helps you plan your *Scenarios* and *Experiences* or assign your *Requirements* to appropriate *Iterations*<link>.
+It does not display the hierarchical parent-child links for the work items and focuses only on the selected work item type group. This helps you plan your *Scenarios* and *Experiences* or assign your *Requirements* to appropriate <<associating_work_items_with_an_iteration,*Iterations*>>.
 
 You can track a particular work item type group using the flat list as follows:
 

--- a/docs/topics/modules/glossary.adoc
+++ b/docs/topics/modules/glossary.adoc
@@ -49,9 +49,11 @@ companion dependency:: Based on the analysis of your stack, {osio} suggests addi
 experience:: An experience is a way to address a scenario, fundamental, or a set of papercuts, each of which often have multiple realizing experiences. Often written as a demonstration script, it describes the ideal end-user work flow for realizing one or more of the associated value propositions.
 // endterm
 
+////
 // term: 9ee45d71-1efe-4fec-b1bb-ac92563327a6, en_EN
 experiences:: Work item type group that focuses on the experience and value proposition work item types that address the scenarios.
 // endterm
+////
 
 // term: dbfc82e1-5a40-44bd-af70-f2dc1a1927a4, en_EN
 feature:: Features, often expressed as user stories, are required to actualize parent experiences. They are scoped so that they are generally achievable within a sprint.
@@ -89,9 +91,11 @@ requirements:: Work item type group that focuses on execution oriented work item
 scenario:: A scenario identifies a real-world user problem to resolve. Addressing the scenario provides tangible user value. Prioritize scenarios that deliver maximum user value by evaluating their associated value propositions.
 // endterm
 
+////
 // term: 376d7613-4eaf-425e-a2f2-b434205ebdeb, en_EN
 scenarios:: Work item type group that focuses on the planning oriented work item types such as scenario, fundamental and papercuts.
 // endterm
+////
 
 // term: eb05f2b6-8a3c-4054-b28c-3eb1a47c125f, en_EN
 scenario-driven planning:: A software development methodology focused on real-world problems, or scenarios, described in the language and from the viewpoint of the user. Scenarios deliver particular value propositions and are realized through experiences.
@@ -128,3 +132,4 @@ work item:: Work items describe and keep track of work that needs to be complete
 // term: e4c8beb4-1ed1-4275-af20-9ee3cb6dafd1, en_EN
 workspace:: Workspaces are fully configured web-based development environments suitable for your code and runtime needs. They are runtime environments where you can modify, test, debug, or run your code.
 // endterm
+

--- a/docs/topics/modules/glossary.adoc
+++ b/docs/topics/modules/glossary.adoc
@@ -38,7 +38,7 @@ backlog:: A backlog is a list of work items that have not been triaged and assig
 // endterm
 
 // term: e8d54bf3-f89e-46e5-86f7-4af6475863b0, en_EN
-bug:: Defect that causes unexpected behavior in the software.
+bug:: A defect that causes unexpected behavior in the software and that needs to be fixed.
 // endterm
 
 // term: 1694e637-2f9b-40ec-8fa8-a22472850ff9, en_EN
@@ -46,32 +46,32 @@ companion dependency:: Based on the analysis of your stack, {osio} suggests addi
 // endterm
 
 // term: 23c322f1-53b1-4286-b524-37ab58124823, en_EN
-experience:: Experience describes the envisioned user experience in the product to actualize a parent work item. Each parent work item can have multiple experiences.
+experience:: An experience is a way to address a scenario, fundamental, or a set of papercuts, each of which often have multiple realizing experiences. Often written as a demonstration script, it describes the ideal end-user work flow for realizing one or more of the associated value propositions.
+// endterm
+
+// term: 9ee45d71-1efe-4fec-b1bb-ac92563327a6, en_EN
+experiences:: Work item type group that focuses on the experience and value proposition work item types that address the scenarios.
 // endterm
 
 // term: dbfc82e1-5a40-44bd-af70-f2dc1a1927a4, en_EN
-feature:: A feature is a detailed user-story that helps actualize parent experiences. It can support multiple experiences and is generally achievable within a sprint.
+feature:: Features, often expressed as user stories, are required to actualize parent experiences. They are scoped so that they are generally achievable within a sprint.
 // endterm
 
-////
-term: 4d85adba-817d-41ca-b85f-1e4a938d1282, en_EN
-fundamental:: Work item type that focuses on getting the basic foundations of a product right to make it more efficient.
+// term: 4d85adba-817d-41ca-b85f-1e4a938d1282, en_EN
+fundamental:: A fundamental describes the basic essentials of a software product, such as quality and performance standards. It is a non-negotiable aspect of a product and its absence reduces the value provided to the user.
 // endterm
-////
 
 // term: 5c1b8158-a351-4092-8780-3ad22e1eb173, en_EN
-iteration:: An iteration is used to organize, plan, and execute work items in a certain order. It comprises a logical mix of work items slated to be executed within the time frame of the iteration.
+iteration:: A development cycle used to organize, plan, and execute work items in a certain order. It comprises a logical mix of work items slated to be executed within the time frame of the iteration.
 // endterm
 
 // term: f05a151a-61fa-45b1-8d8b-b3fd7bc63ea9, en_EN
 license conflict:: Licenses that conflict at the stack or dependency level.
 // endterm
 
-////
-term: 83b7cf12-558e-41bd-bcd7-822ca6307db1, en_EN
-papercuts:: Papercuts are logical aggregations of minor issues that collectively have a negative impact on the user. This aggregation receives higher priority and enables efficient handling of such issues.
+// term: 83b7cf12-558e-41bd-bcd7-822ca6307db1, en_EN
+papercut:: A papercut is a minor issue, often too small to be individually prioritized to be addressed; collectively, papercuts degrade the perception of the product. Grouped together, they receive higher priority and can be tackled together within a development cycle.
 // endterm
-////
 
 // term: 5bd840a6-2f62-4bea-bb04-63252f6ce381, en_EN
 pipeline:: Pipelines are a continuous delivery system that, at each step, tests and deploys the code to provide feedback to the user. Examples of such steps are unit testing, performance, integration, and deployment. Each step of the pipeline implements different levels of testing and deployment tasks, provides results, and then passes the code on to the next step.
@@ -81,11 +81,17 @@ pipeline:: Pipelines are a continuous delivery system that, at each step, tests 
 restrictive license:: Licenses that are not commonly used in similar stacks or that do not work well with the stack’s representative license.
 // endterm
 
-////
-term: 01e76137-ab89-4a3c-8765-48f54078154a, en_EN
-scenario:: Work item type that identifies and tries to resolve real world problems faced by users, mostly defined in a broad sense.
+// term: a0b10d4f-f639-4978-a2e5-6e858a56f6df, en_EN
+requirements:: Work item type group that focuses on execution oriented work item types such as feature, task, and bug.
 // endterm
-////
+
+// term: 01e76137-ab89-4a3c-8765-48f54078154a, en_EN
+scenario:: A scenario identifies a real-world user problem to resolve. Addressing the scenario provides tangible user value. Prioritize scenarios that deliver maximum user value by evaluating their associated value propositions.
+// endterm
+
+// term: 376d7613-4eaf-425e-a2f2-b434205ebdeb, en_EN
+scenarios:: Work item type group that focuses on the planning oriented work item types such as scenario, fundamental and papercuts.
+// endterm
 
 // term: eb05f2b6-8a3c-4054-b28c-3eb1a47c125f, en_EN
 scenario-driven planning:: A software development methodology focused on real-world problems, or scenarios, described in the language and from the viewpoint of the user. Scenarios deliver particular value propositions and are realized through experiences.
@@ -112,7 +118,7 @@ usage outlier:: Dependencies in your stack that are not commonly used in similar
 // endterm
 
 // term: 83e52577-cdc4-4687-97d1-86151db74bdc, en_EN
-value proposition:: Work item type that states the value provided to the user by addressing a parent work item. Each parent work item can have multiple value propositions.
+value proposition:: A statement of the value provided to the user by addressing a scenario, fundamental, or papercut. Each of which can have multiple value propositions.
 // endterm
 
 // term: 83e7953e-9335-428c-b1af-7aa4b00cd662, en_EN

--- a/json/infotips.json
+++ b/json/infotips.json
@@ -20,49 +20,55 @@
 {
    "e8d54bf3-f89e-46e5-86f7-4af6475863b0": {
       "term": "bug",
-      "en_EN": "Defect that causes unexpected behavior in the software."
+      "en_EN": "A defect that causes unexpected behavior in the software and that needs to be fixed."
    }
 },
 {
    "1694e637-2f9b-40ec-8fa8-a22472850ff9": {
-      "term": "companinon dependency",
+      "term": "companion dependency",
       "en_EN": "Based on the analysis of your stack, {osio} suggests additional dependencies that can add value to your stack."
    }
 },
 {
    "23c322f1-53b1-4286-b524-37ab58124823": {
       "term": "experience",
-      "en_EN": "Experience describes the envisioned user experience in the product to actualize a parent work item. Each parent work item can have multiple experiences."
+      "en_EN": "An experience is a way to address a scenario, fundamental, or a set of papercuts, each of which often have multiple realizing experiences. Often written as a demonstration script, it describes the ideal end-user work flow for realizing one or more of the associated value propositions."
+   }
+},
+{
+   "9ee45d71-1efe-4fec-b1bb-ac92563327a6": {
+      "term": "experiences",
+      "en_EN": "Work item type group that focuses on the experience and value proposition work item types that address the scenarios."
    }
 },
 {
    "dbfc82e1-5a40-44bd-af70-f2dc1a1927a4": {
       "term": "feature",
-      "en_EN": "A feature is a detailed user-story that helps actualize parent experiences. It can support multiple experiences and is generally achievable within a sprint."
-   }
-},
-{
-   "e8d54bf3-f89e-46e5-86f7-4af6475863b0": {
-      "term": "bug",
-      "en_EN": "Defect that causes unexpected behavior in the software."
+      "en_EN": "Features, often expressed as user stories, are required to actualize parent experiences. They are scoped so that they are generally achievable within a sprint."
    }
 },
 {
    "4d85adba-817d-41ca-b85f-1e4a938d1282": {
       "term": "fundamental",
-      "en_EN": "Work item type that focuses on getting the basic foundations of a product right to make it more efficient."
+      "en_EN": "A fundamental describes the basic essentials of a software product, such as quality and performance standards. It is a non-negotiable aspect of a product and its absence reduces the value provided to the user."
    }
 },
 {
    "5c1b8158-a351-4092-8780-3ad22e1eb173": {
       "term": "iteration",
-      "en_EN": "An iteration is used to organize, plan, and execute work items in a certain order. It comprises a logical mix of work items slated to be executed within the time frame of the iteration."
+      "en_EN": "A development cycle used to organize, plan, and execute work items in a certain order. It comprises a logical mix of work items slated to be executed within the time frame of the iteration."
    }
 },
 {
    "f05a151a-61fa-45b1-8d8b-b3fd7bc63ea9": {
       "term": "license conflict",
       "en_EN": "Licenses that conflict at the stack or dependency level."
+   }
+},
+{
+   "83b7cf12-558e-41bd-bcd7-822ca6307db1": {
+      "term": "papercut",
+      "en_EN": "A papercut is a minor issue, often too small to be individually prioritized to be addressed; collectively, papercuts degrade the perception of the product. Grouped together, they receive higher priority and can be tackled together within a development cycle."
    }
 },
 {
@@ -75,6 +81,24 @@
    "3a953b07-0cc3-4b45-b891-bf490216eae3": {
       "term": "restrictive license",
       "en_EN": "Licenses that are not commonly used in similar stacks or that do not work well with the stack’s representative license."
+   }
+},
+{
+   "a0b10d4f-f639-4978-a2e5-6e858a56f6df": {
+      "term": "requirements",
+      "en_EN": "Work item type group that focuses on execution oriented work item types such as feature, task, and bug."
+   }
+},
+{
+   "01e76137-ab89-4a3c-8765-48f54078154a": {
+      "term": "scenario",
+      "en_EN": "A scenario identifies a real-world user problem to resolve. Addressing the scenario provides tangible user value. Prioritize scenarios that deliver maximum user value by evaluating their associated value propositions."
+   }
+},
+{
+   "376d7613-4eaf-425e-a2f2-b434205ebdeb": {
+      "term": "scenarios",
+      "en_EN": "Work item type group that focuses on the planning oriented work item types such as scenario, fundamental and papercuts."
    }
 },
 {
@@ -116,7 +140,7 @@
 {
    "83e52577-cdc4-4687-97d1-86151db74bdc": {
       "term": "value proposition",
-      "en_EN": "Work item type that states the value provided to the user by addressing a parent work item. Each parent work item can have multiple value propositions."
+      "en_EN": "A statement of the value provided to the user by addressing a scenario, fundamental, or papercut. Each of which can have multiple value propositions."
    }
 },
 {


### PR DESCRIPTION
Apart from adding SDD concepts to glossary
Fixed few strays from the Integration guide changes: 
- Updated App id for consistency in all api topics.
- Removed reference to recommender.api
Fixed mention of <link> in Flat view topic