### PR TITLE
Build on RHEL and move from caddy to nginx

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,5 +1,24 @@
-FROM fabric8/caddy:v8759201
+FROM centos:7
+LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
 
-COPY html /var/www/html/
-RUN mkdir -p /var/www/html/json/
-COPY json /var/www/html/json/
+ENV LANG=en_US.utf8
+ENV FABRIC8_USER_NAME=fabric8
+
+ADD root /
+
+RUN yum install --setopt=tsflags=nodocs -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    yum -y install --setopt=tsflags=nodocs nginx gettext && \
+    yum clean all && \
+    rm -f /usr/share/nginx/html/* && \
+    useradd --no-create-home -s /bin/bash ${FABRIC8_USER_NAME} && \
+    chmod -R 777 /run.sh /usr/share/nginx/html /run /var/log/nginx && \
+    chmod -R a+rw /etc/nginx
+
+COPY html /usr/share/nginx/html/
+COPY json /usr/share/nginx/html/json/
+
+USER ${FABRIC8_USER_NAME}
+
+EXPOSE 8080
+ENTRYPOINT ["/run.sh"]

--- a/Dockerfile.deploy.rhel
+++ b/Dockerfile.deploy.rhel
@@ -1,0 +1,6 @@
+FROM prod.registry.devshift.net/osio-prod/base/openshift-nginx:latest
+LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
+
+COPY html /usr/share/nginx/html/
+COPY json /usr/share/nginx/html/json/

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -4,24 +4,35 @@ GENERATOR_DOCKER_HUB_USERNAME=openshiftioadmin
 REGISTRY_URI="push.registry.devshift.net"
 REGISTRY_NS="fabric8io"
 REGISTRY_IMAGE="fabric8-online-docs"
-REGISTRY_URL=${REGISTRY_URI}/${REGISTRY_NS}/${REGISTRY_IMAGE}
 BUILDER_IMAGE="docs-builder"
 BUILDER_CONT="docs-builder-container"
 DEPLOY_IMAGE="docs-deploy"
 DEPLOY_CONT="docs-deploy-container"
 
+if [ "$TARGET" = "rhel" ]; then
+    REGISTRY_URL=${REGISTRY_URI}/osio-prod/${REGISTRY_NS}/${REGISTRY_IMAGE}
+    DOCKERFILE_DEPLOY="Dockerfile.deploy.rhel"
+else
+    REGISTRY_URL=${REGISTRY_URI}/${REGISTRY_NS}/${REGISTRY_IMAGE}
+    DOCKERFILE_DEPLOY="Dockerfile.deploy"
+fi
+
 TARGET_DIR="html"
 
-function tag_push() {
-    TARGET_IMAGE=$1
-    USERNAME=$2
-    PASSWORD=$3
-    REGISTRY=$4
+function docker_login() {
+    local USERNAME=$1
+    local PASSWORD=$2
+    local REGISTRY=$3
 
-    docker tag ${DEPLOY_IMAGE} ${TARGET_IMAGE}
     if [ -n "${USERNAME}" ] && [ -n "${PASSWORD}" ]; then
         docker login -u ${USERNAME} -p ${PASSWORD} ${REGISTRY}
     fi
+}
+
+function tag_push() {
+    local TARGET_IMAGE=$1
+
+    docker tag ${DEPLOY_IMAGE} ${TARGET_IMAGE}
     docker push ${TARGET_IMAGE}
 }
 
@@ -33,10 +44,7 @@ if [ -z $CICO_LOCAL ]; then
     [ -f inherit-env ] && . inherit-env
 
     # We need to disable selinux for now, XXX
-    /usr/sbin/setenforce 0
-
-    # Get all the deps in
-    yum -y install docker make git
+    /usr/sbin/setenforce 0 || :
 
     # Get all the deps in
     yum -y install docker make git
@@ -51,7 +59,7 @@ docker ps -a | grep -q ${BUILDER_CONT} && docker rm ${BUILDER_CONT}
 if [ -d $TARGET_DIR ]; then rm -rf ${TARGET_DIR}/; fi
 
 #CREATE A FRESH DIR FOR BUILT DOCS TO BE PUT INTO
-mkdir -m 777 ${TARGET_DIR}
+mkdir -pm 777 ${TARGET_DIR}
 
 #BUILD BUILDER IMAGE
 docker build -t ${BUILDER_IMAGE} -f Dockerfile.build .
@@ -59,14 +67,19 @@ docker build -t ${BUILDER_IMAGE} -f Dockerfile.build .
 #RUN BUILDER CONTAINER ONCE, THUS BUILDING THE DOCS
 docker run --rm --name=${BUILDER_CONT} -it --volume=$(pwd)/${TARGET_DIR}:/${TARGET_DIR}:Z ${BUILDER_IMAGE}
 
+#LOGIN IS REQUIRED FOR BUILDING ON RHEL
+if [ -z "$CICO_LOCAL" ]; then
+  docker_login "${DEVSHIFT_USERNAME}" "${DEVSHIFT_PASSWORD}" "${REGISTRY_URI}"
+fi
+
 #BUILD DEPLOY IMAGE
-docker build -t ${DEPLOY_IMAGE} -f Dockerfile.deploy .
+docker build -t ${DEPLOY_IMAGE} -f "${DOCKERFILE_DEPLOY}" .
 
 #PUSH
 if [ -z $CICO_LOCAL ]; then
     TAG=$(echo $GIT_COMMIT | cut -c1-${DEVSHIFT_TAG_LEN})
-    tag_push "${REGISTRY_URL}:${TAG}" ${DEVSHIFT_USERNAME} ${DEVSHIFT_PASSWORD} ${REGISTRY_URI}
-    tag_push "${REGISTRY_URL}:latest" ${DEVSHIFT_USERNAME} ${DEVSHIFT_PASSWORD} ${REGISTRY_URI}
+    tag_push "${REGISTRY_URL}:${TAG}"
+    tag_push "${REGISTRY_URL}:latest"
 fi
 
 #SERVE DOCS WHEN ON LOCAL

--- a/openshift/fabric8-online-docs.app.yaml
+++ b/openshift/fabric8-online-docs.app.yaml
@@ -98,7 +98,7 @@ objects:
           group: io.fabric8.apps
       spec:
         containers:
-        - image: registry.devshift.net/fabric8io/fabric8-online-docs:${IMAGE_TAG}
+        - image: ${IMAGE}:${IMAGE_TAG}
           livenessProbe:
             httpGet:
               path: /
@@ -139,5 +139,7 @@ objects:
       kind: Service
       name: fabric8-online-docs-app
 parameters:
+- name: IMAGE
+  value: registry.devshift.net/fabric8io/fabric8-online-docs
 - name: IMAGE_TAG
   value: latest

--- a/root/etc/nginx/nginx.conf
+++ b/root/etc/nginx/nginx.conf
@@ -1,0 +1,71 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+
+worker_processes 1;
+error_log /dev/stdout info;
+pid /run/nginx.pid;
+daemon off;
+
+# Load dynamic modules. See /usr/share/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log 		/dev/stdout main;
+    client_body_temp_path /tmp;
+    fastcgi_temp_path /tmp;
+    scgi_temp_path /tmp;
+    proxy_temp_path /tmp;
+    uwsgi_temp_path /tmp;
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /etc/nginx/conf.d/*.conf;
+
+    server {
+        listen       8080 default_server;
+        server_name  _;
+        root         /usr/share/nginx/html;
+
+        # Load configuration files for the default server block.
+        include /etc/nginx/default.d/*.conf;
+
+        location / {
+        }
+
+        error_page 404 /404.html;
+            location = /40x.html {
+        }
+
+        error_page 500 502 503 504 /50x.html;
+            location = /50x.html {
+        }
+
+        gzip            on;
+        gzip_min_length 1000;
+        gzip_comp_level 9;
+        gzip_proxied    expired no-cache no-store private auth;
+        gzip_types      text/plain text/css application/javascript application/xml;
+    }
+
+# Settings for a TLS enabled server.
+# - we dont do TLS here, offload that to the openshift edge instead
+
+}
+

--- a/root/run.sh
+++ b/root/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+echo "----"
+id
+echo "----"
+
+ls -al /var/lib/nginx/
+ls -al /var/log/nginx/
+
+nginx -c /etc/nginx/nginx.conf


### PR DESCRIPTION
Enables build on RHEL if TARGET=rhel:

- The build scripts will be executed twice on the same machine, once for
  CentOS and one for RHEL
- `docker login` is required to run `docker build`
- The image target is different if TARGET=rhel
- There is a separate Dockerfile for the RHEL build

Additionally, it replaces caddy with nginx as the static web server, to match
other services in OSIO.

When this is merged it will be automatically deployed to staging based on RHEL,
but prod will be kept on CentOS.