### PR TITLE
Added note about states of WIs being determined by space development …

### DIFF
--- a/docs/topics/getting-started-guide.adoc
+++ b/docs/topics/getting-started-guide.adoc
@@ -9,7 +9,7 @@ include::before_you_start.adoc[leveloffset=+1]
 
 = Start using {osio}
 
-//include::modules/introduction_to_homescreen.adoc[leveloffset=+1]
+include::modules/introduction_to_homescreen.adoc[leveloffset=+1]
 
 include::hello_world_developers.adoc[leveloffset=+1]
 

--- a/docs/topics/hello_world_developers.adoc
+++ b/docs/topics/hello_world_developers.adoc
@@ -21,8 +21,6 @@ include::modules/approving_build_pipeline.adoc[leveloffset=+1]
 
 include::modules/optional_detailed_views.adoc[leveloffset=+1]
 
-//include::modules/creating_using_new_work_item.adoc[leveloffset=+1]
-
 include::modules/about_workspaces.adoc[leveloffset=+1]
 
 include::modules/creating_che_workspace.adoc[leveloffset=+1]

--- a/docs/topics/modules/about_workspaces.adoc
+++ b/docs/topics/modules/about_workspaces.adoc
@@ -1,8 +1,8 @@
 [id="about_workspaces"]
 = About workspaces
 
-After creating and testing your new Vert.x Quickstart application, you can make changes to the project code. {osio} provides hosted instances of Eclipse Che within your browser to edit, test, and debug your project code.
+After creating and testing your new Vert.x quickstart application, you can make changes to the project code. {osio} provides hosted instances of Eclipse Che within your browser to edit, test, and debug your project code.
 
 One of the key features of Eclipse Che is Che _workspaces_, which provide a fully configured runtime environment for running your code. As a result, {osio} provides a lightweight, next generation IDE as well as a containerized development and testing environment.
 
-When you use the Quickstart Application Wizard in {osio}, the development and testing environment is automatically configured with the necessary runtime components and is ready to use. Thereby {osio} uses Che workspaces to provide you with a personal development machine each time you start working on a new project.
+When you use the quickstart application wizard in {osio}, the development and testing environment is automatically configured with the necessary runtime components and is ready to use. Thereby {osio} uses Che workspaces to provide you with a personal development machine each time you start working on a new project.

--- a/docs/topics/modules/about_workspaces_user-guide.adoc
+++ b/docs/topics/modules/about_workspaces_user-guide.adoc
@@ -1,8 +1,8 @@
 [id="about_workspaces_user-guide"]
 = About workspaces
 
-After importing an existing application or creating and then testing a new application, you can make changes to the code using workspaces. {osio} provides hosted instances of Eclipse Che within your browser to edit, test, and debug your project code. 
+After creating and then testing a new application or importing an existing application, you can make changes to the code using workspaces. {osio} provides hosted instances of Eclipse Che within your browser to edit, test, and debug your project code. 
 
 One of the key features of Eclipse Che is Che _workspaces_, which provide a fully configured runtime environment for running your code. As a result, {osio} provides a lightweight, next generation IDE as well as a containerized development and testing environment.
 
-When you use the Quickstart Application Wizard in {osio}, the development and testing environment is automatically configured with the necessary runtime components and is ready to use. Thereby {osio} uses Che workspaces to provide you with a personal development machine each time you start working on a new project.
+When you use the quickstart application wizard in {osio}, the development and testing environment is automatically configured with the necessary runtime components and is ready to use. Thereby {osio} uses Che workspaces to provide you with a personal development machine each time you start working on a new project.

--- a/docs/topics/modules/adding_github_org.adoc
+++ b/docs/topics/modules/adding_github_org.adoc
@@ -10,20 +10,20 @@
 +
 image:new_org_fields.png[New organization fields]
 +
-.. Under `Choose your plan`, select *Free*.
+.. Under *Choose your plan*, select *Free*.
 .. Click btn:[Create organization].
-.. In the `Invite organization members` screen, add users or click btn:[Continue] to skip this step.
+.. In the *Invite organization members* screen, add users or click btn:[Continue] to skip this step.
 .. Either select details for your organization and click btn:[Submit] or click *skip this step*. The new organization details now display.
 
 . In the same browser tab, navigate to https://github.com/settings/organizations
 
 . Click *Openshift.io* from the list of applications.
 
-. In the details page for the application, your new organization is listed under `Organization access`. Click btn:[Grant] to give the new organization access.
+. In the details page for the application, your new organization is listed under *Organization access*. Click btn:[Grant] to give the new organization access.
 
 . Return to the {osio} tab in your browser.
 
-. Navigate to your `Settings` view:
+. Navigate to your *Settings* view:
 
 .. Click your name on the top right corner of the screen.
 
@@ -31,10 +31,10 @@ image:new_org_fields.png[New organization fields]
 +
 image::profile_settings.png[Profile menu button]
 +
-. Under `Connected Accounts`, click the refresh icon for your GitHub account.
+. Under *Connected Accounts*, click the refresh icon for your GitHub account.
 +
 image::refresh_github.png[Refresh github]
 +
-. After the reloaded {osio} screen loads, your new organization is added. 
+. After the reloaded {osio} screen loads, your new organization is added.
 
 To use the new organization, create a new project and in the *Organization* drop-down menu, your new organization is listed.

--- a/docs/topics/modules/approving_build_pipeline.adoc
+++ b/docs/topics/modules/approving_build_pipeline.adoc
@@ -7,7 +7,7 @@ The build pipeline includes steps for a _Stage_ build and a _Run_ build. _Stage_
 
 To stage your application and review it on _Stage_:
 
-. If you are not on the `Pipelines` view, click btn:[Create] from the options at the top of the screen and then click btn:[Pipelines].
+. If you are not on the *Pipelines* view, click btn:[Create] from the options at the top of the screen and then click btn:[Pipelines].
 . Click the icon (image:rollout_icon.png[title="Rollout"]) next to *Rollout to Stage* in the displayed pipeline. OpenShift Online provides this public URL to access the staged quickstart application.
 +
 image::rollout_stage.png[Rollout to stage]

--- a/docs/topics/modules/changing_your_password.adoc
+++ b/docs/topics/modules/changing_your_password.adoc
@@ -3,7 +3,7 @@
 
 In the {osio} dashboard view, use the following steps to change your password:
 
-. Navigate to your `Profile` view:
+. Navigate to your *Profile* view:
 
 .. Click your name on the top right corner of the screen.
 
@@ -11,11 +11,11 @@ In the {osio} dashboard view, use the following steps to change your password:
 +
 image::profile_menu.png[Profile menu button]
 +
-. In the `Profile` screen, click btn:[Update Profile] to edit your profile.
+. In the *Profile* screen, click btn:[Update Profile] to edit your profile.
 +
 image::update_profile_button.png[Update profile button]
 +
-. At the bottom of the `Edit Profile` screen, click btn:[Change password]. You are redirected to the Red Hat Developers `Change Password` page.
+. At the bottom of the *Edit Profile* screen, click btn:[Change password]. You are redirected to the Red Hat Developers *Change Password* page.
 +
 image::change_password_button.png[Change password button]
 +

--- a/docs/topics/modules/changing_your_privacy_settings.adoc
+++ b/docs/topics/modules/changing_your_privacy_settings.adoc
@@ -3,7 +3,7 @@
 
 In the {osio} dashboard view, use the following steps to change your privacy settings:
 
-. Navigate to your `Profile` view:
+. Navigate to your *Profile* view:
 
 .. Click your name on the top right corner of the screen.
 
@@ -11,15 +11,14 @@ In the {osio} dashboard view, use the following steps to change your privacy set
 +
 image::profile_menu.png[Profile menu button]
 +
-. In the `Profile` screen, click btn:[Update Profile] to edit your profile.
+. In the *Profile* screen, click btn:[Update Profile] to edit your profile.
 +
 image::update_profile_button.png[Update profile button]
 +
-. In the `Edit Profile` screen, you can select *Private* or *Public* for your information. The default option is *Public* but setting this to *Private* hides your email address from other users in {osio}.
+. In the *Edit Profile* screen, you can select *Private* or *Public* for your information. The default option is *Public* but setting this to *Private* hides your email address from other users in {osio}.
 +
 image::private_public.png[Public and private]
 +
 . When ready, click btn:[Update] at the bottom of the page to save your changes.
 
 You have now change your profile privacy settings in {osio}.
-

--- a/docs/topics/modules/create_run_command_macro.adoc
+++ b/docs/topics/modules/create_run_command_macro.adoc
@@ -1,7 +1,7 @@
 [id="create_run_command_macro"]
 = Create run command macro
 
-If your Che workspace does not already include a *run* command macro, clicking the Run icon displays a `Create run command` option:
+If your Che workspace does not already include a *run* command macro, clicking the Run icon displays a *Create run command* option:
 
 image::create_run_command.png[Create run command]
 
@@ -9,21 +9,21 @@ To create the run command:
 
 . Click *Create run command*.
 . Add the following information for the new command:
-.. In the `Name` field, type *run* to name the new command shortcut.
+.. In the *Name* field, type `run` to name the new command shortcut.
 .. In the command box, type the following command:
 +
 ----
 scl enable rh-maven33 'mvn compile vertx:run -f ${current.project.path}'
 ----
 +
-.. Toggle the `Applicable` option to *YES* to enable this macro for your project.
+.. Toggle the *Applicable* option to *YES* to enable this macro for your project.
 +
 image::add_details_run_command.png[Add details create run]
 . Click *RUN* on the right side of the screen to run your new macro.
 +
 image::run_macro.png[Run macros]
 +
-. In the `Terminal` view at the bottom of the workspace, the command runs. When successfully complete, the command displays the following message:
+. In the *Terminal* view at the bottom of the workspace, the command runs. When successfully complete, the command displays the following message:
 +
 ----
 [INFO] INFO: Succeeded in deploying verticle

--- a/docs/topics/modules/opting_in_to_features.adoc
+++ b/docs/topics/modules/opting_in_to_features.adoc
@@ -3,7 +3,7 @@
 
 In the {osio} dashboard view, use the following steps to opt in or out of features:
 
-. Navigate to your `Profile` view:
+. Navigate to your *Profile* view:
 
 .. Click your name on the top right corner of the screen.
 
@@ -11,7 +11,7 @@ In the {osio} dashboard view, use the following steps to opt in or out of featur
 +
 image::profile_settings.png[Profile menu button]
 +
-. In the `Settings` screen, click *Features Opt-in*.
+. In the *Settings* screen, click *Features Opt-in*.
 +
 image::features_optin.png[Features Opt In]
 +

--- a/docs/topics/modules/optional_detailed_views.adoc
+++ b/docs/topics/modules/optional_detailed_views.adoc
@@ -7,7 +7,7 @@ View the details for the *Deployments* as follows:
 
 . Navigate to the *Deployments* view:
 .. At the top of the page, click btn:[Create].
-.. From the options displayed, click btn:[Deployments]. 
+.. From the options displayed, click btn:[Deployments].
 +
 image::create_deployments_menu.png[Create > Deployments]
 +
@@ -17,7 +17,7 @@ image::deployments_page.png[Deployments page warning]
 +
 . Click btn:[Opt-in to Experimental Features].
 
-. On the profile options page, select the `Experimental Features` option.
+. On the profile options page, select the *Experimental Features* option.
 +
 image::features_options.png[Features options]
 +

--- a/docs/topics/modules/reviewing_publishing_changes.adoc
+++ b/docs/topics/modules/reviewing_publishing_changes.adoc
@@ -37,9 +37,9 @@ image::expand_version.png[Expand the application version]
 . Click *Pipelines* to return to the pipelines view.
 . At the *Approve* stage, click btn:[Input Required].
 . Click btn:[Promote] to promote version 1.0.2 of the application to *Run*.
-
++
 Your changes are now available on both *Stage* and *Run*. If you return to the *Deployments* tab, you can see the version for both *Stage* and *Run* are now 1.0.2.
-
++
 image::updated_app.png[Updated applications]
 +
 //for hello world
@@ -50,10 +50,13 @@ ifeval::["{context}" == "hello-world"]
 
 Well done! You have now created your first quickstart project in {osio}, used the planner to track and execute your work, made changes to your project code, committed the changes to GitHub, and published the new version of your project.
 endif::[]
+
+
 //for importing existing
 ifeval::["{context}" == "importing-existing-project"]
 Well done! You have now imported an existing project into {osio}, used a work item to track your work, made changes to your project code, committed the changes to GitHub, and published the new version of your project.
 endif::[]
+
 
 //for user guide
 ifeval::["{context}" == "user-guide"]

--- a/docs/topics/modules/tracking_state_of_a_work_item.adoc
+++ b/docs/topics/modules/tracking_state_of_a_work_item.adoc
@@ -3,12 +3,20 @@
 
 You can set the state for each of your work items enabling you to track the status of your work item from creation to completion.
 
+NOTE: The *Development Process* you select while creating your space determines the guided work item type hierarchy, the available work item types, and the available states of the work item in planner.
+
+For this example, select the scenario driven *Development Process*.
 By default, a freshly created work item is assigned the *new* state.
 You can track and update the status of work items as you progress through your task list as follows:
 
 . Click the *new* drop-down list to see a list of states for the work item. You have the following options: *open*, *in progress*, *resolved* and *closed*.
 +
 image::wi_state.png[Work Item state]
+
+NOTE: The Scrum template provides you the following options: *New*, *In-Progress*, *Done*, *Removed*.
+
 . Select the appropriate state based on the completion level of your work item. The state for the work item gets updated.
 
 NOTE: By default, closed work items are not listed in the work item list. Select the *Show Completed* checkbox to see the closed work items.
+
+//TODO: Cases of state will be changed, capture them.

--- a/docs/topics/modules/using_scrum_guided_hierarchy.adoc
+++ b/docs/topics/modules/using_scrum_guided_hierarchy.adoc
@@ -1,7 +1,11 @@
 [id="using_scrum_guided_hierarchy"]
 = Using the Scrum guided hierarchy
 
-Scrum is an iterative and incremental agile software development framework for managing product development. Use the scrum guided hierarchy to create work items as follows:
+Scrum is an iterative and incremental agile software development framework for managing product development.
+
+NOTE: The *Development Process* you select while creating your space determines the guided work item type hierarchy, the available work item types, and the available states of the work item in planner.
+
+Use the scrum guided hierarchy to create work items as follows:
 
 .Prerequisites
 

--- a/docs/topics/modules/using_sdd_guided_hierarchy.adoc
+++ b/docs/topics/modules/using_sdd_guided_hierarchy.adoc
@@ -2,6 +2,9 @@
 = Using the Scenario Driven Development guided hierarchy
 
 Scenario driven development is an agile development methodology focused on real-world problems, or scenarios, described in the language and from the viewpoint of the user. Scenarios deliver particular value propositions and are realized through experiences.
+
+NOTE: The *Development Process* you select while creating your space determines the guided work item type hierarchy, the available work item types in planner, and the available states of the work item in planner..
+
 Use the scenario driven guided hierarchy to create work items as follows:
 
 .Prerequisites


### PR DESCRIPTION
…process and cleaned up all the unneeded backticks and made all the Quickstarts small case.
Hopefully all the backticks have been taken care of, I have gone through both the guides and tried to sanitize it.
As per the Asciidoc convention we use backticks only for commands, folders, directories, user input where user is typing in some input, either a command or a textual input.
@rkratky please correct me if I have missed out on anything.