### PR TITLE
Pin Fedora image tag to 27 to fix dependency issues

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:27
 
 MAINTAINER Robert Kratky <rkratky@redhat.com>
 


### PR DESCRIPTION
Fix failed dependencies. 
Fedora:latest now resolves to `28`, on which we're seeing failed dependency errors
https://github.com/fabric8io/fabric8-online-docs/issues/340

PS: We may need to look for a better longer term solution, and see why the dependencies broke on upstream repositories to move to 28, but this should work for now.