### PR TITLE
Moved areas section before collaborators as both are related to each …

### DIFF
--- a/docs/topics/modules/about_areas.adoc
+++ b/docs/topics/modules/about_areas.adoc
@@ -3,6 +3,6 @@
 
 _Areas_ can organize related <<about_work_items,work items>> into groups to distinguish between different types or functionalities that are worked on within a <<about_spaces,space>>.
 
-A space can also include areas. As an example, your space represents your software project, and each area tracks components attached to the space.
+A space can include multiple areas. As an example, your space represents your software project, and each area tracks components attached to the space.
 
 Each area can have child areas which represent the sub-components for your software project.

--- a/docs/topics/modules/adding_collaborators.adoc
+++ b/docs/topics/modules/adding_collaborators.adoc
@@ -11,7 +11,7 @@ You can add other {osio} users as collaborators to your space and then assign wo
 .Procedure
 
 . From your {osio} dashboard, click the name of a space to view its dashboard.
-. Click the Equalizer icon (image:equalizer.png[title="Settings"]) at the top of the screen.
+. Click the Equalizer tab (image:equalizer.png[title="Settings"]) at the top of the screen.
 . Click *Collaborators*.
 +
 image::collaborators_button.png[Collaborators button]

--- a/docs/topics/modules/associating_work_item_with_area.adoc
+++ b/docs/topics/modules/associating_work_item_with_area.adoc
@@ -7,7 +7,7 @@ By default, the name of your space is set as the root area for a work item.
 
 To assign a new area for your work item:
 
-. In the *Area* field, click the root area to see the the areas you can associate the work item with. The list of available areas for a space is set by the administrator for the space.
+. In the *Area* field, click the root area to see the areas you can associate the work item with. The list of available areas for a space is set by the administrator for the space.
 +
 image::wi_associate_area.png[Work Item-Area Association]
 . Select the required area and click *✓* to save the change.

--- a/docs/topics/modules/creating_a_new_area.adoc
+++ b/docs/topics/modules/creating_a_new_area.adoc
@@ -1,15 +1,16 @@
 [id="creating_a_new_area"]
 = Creating a new area
 
-You can create a new child area to group together related work items by type or functionality. When you create a new space, {osio} automatically creates a root area with the same name. Each additional area within the space is created as a child of the root area or another existing area in the space.
+You can create a new child area to group together related work items by type or functionality. When you create a new space, {osio} automatically creates a root area with the same name. Each additional area within the space is created as a child of the root area or another existing area in the space. 
 
 .Prerequisites
 
-* Ensure you have <<creating_new_space-user-guide,created a space>> to use.
+* <<creating_new_space-user-guide,Create a new space>> or select an existing space.
 
 .Procedure
 
-. At the top of the page, click the *Equalizer* button (image:equalizer.png[title="Settings"]) to display a list of areas in your space.
+. From your {osio} dashboard, click the name of a space to view its dashboard.
+. At the top of the page, click the *Equalizer* tab (image:equalizer.png[title="Settings"]) to display a list of areas in your space.
 . In the top right corner of the *Areas* view, click *Add Areas*.
 +
 image::add_areas_button.png[Add areas button]

--- a/docs/topics/modules/viewing_and_changing_collaborators.adoc
+++ b/docs/topics/modules/viewing_and_changing_collaborators.adoc
@@ -11,7 +11,7 @@ After adding collaborators, you can view their details or remove them from your 
 
 .Procedure
 
-. Click the *Equalizer* button (image:equalizer.png[title="Equalizer"]) at the top of the screen.
+. Click the *Equalizer* tab (image:equalizer.png[title="Equalizer"]) at the top of the screen.
 . Click btn:[Collaborators].
 +
 image::collaborators_button.png[Collaborators button]

--- a/docs/topics/user-guide.adoc
+++ b/docs/topics/user-guide.adoc
@@ -18,13 +18,13 @@ include::changing_user_preferences.adoc[leveloffset=+1]
 
 include::working_with_spaces.adoc[leveloffset=+1]
 
+include::working_with_areas.adoc[leveloffset=+1]
+
 include::working_with_collaborators.adoc[leveloffset=+1]
 
 include::working_with_work_items.adoc[leveloffset=+1]
 
 include::working_with_iterations.adoc[leveloffset=+1]
-
-include::working_with_areas.adoc[leveloffset=+1]
 
 include::working_with_codebases.adoc[leveloffset=+1]
 


### PR DESCRIPTION
…other and a user will need to work on Areas before he moves on to Planner.

As part of #368 the agenda was also to unify and reuse modules:
- [Associating a work item with an area](https://docs.openshift.io/user-guide.html#associating_work_item_with_area) and [Assigning an area to a work item](https://docs.openshift.io/user-guide.html#Assigning_an_area)
- [Assigning the work item](https://docs.openshift.io/user-guide.html#assigning_the_work_item) and [Assigning a collaborator](https://docs.openshift.io/user-guide.html#assigning_a_collaborator)

However, with lots of changes coming up in the collaborators and Areas section, we could probably retain these modules in the Areas and Collaborators section, as there will be plenty of additional stuff that may need to go into those modules.
