### PR TITLE
I370 f8 restructure resource content

### DIFF
--- a/docs/topics/changing_user_preferences.adoc
+++ b/docs/topics/changing_user_preferences.adoc
@@ -14,3 +14,5 @@ include::modules/adding_github_org.adoc[leveloffset=+1]
 include::modules/opting_in_to_features.adoc[leveloffset=+1]
 
 include::modules/viewing_resource_usage.adoc[leveloffset=+1]
+
+include::modules/reviewing_detailed_resource_information.adoc[leveloffset=+1]

--- a/docs/topics/modules/monitoring_your_oso_quota_usage.adoc
+++ b/docs/topics/modules/monitoring_your_oso_quota_usage.adoc
@@ -1,7 +1,7 @@
 [id="monitoring_your_oso_quota_usage"]
 = View your detailed OpenShift Online quota usage
 
-An additional way to view the resource details for your projects is available in OpenShift Online. Use the following instructions to see these details:
+After committing your changes, view the resource details for your project again in OpenShift Online. Use the following instructions to see these details:
 
 . Click *Create* and then *Pipelines* to view the new pipeline build. Committing and pushing your new YAML file triggers a new pipeline build for your {osio} project. Allow several minutes for the pipeline build to roll out to *Stage*:
 +
@@ -12,5 +12,7 @@ image::rollout_to_stage.png[Rollout To Stage]
 image::optimize_memory.png[Optimizing HW Memory Usage]
 +
 . <<approving_build_pipeline,Promote the application>> to the *Run* environment.
++
+You can now compare these details to the details in <<reviewing_detailed_resource_information-{context}>> to see the resource usage improvements.
 
 NOTE: If you have completed these instructions for optimizing your resources but still do not have enough OpenShift Online resources, see <<cleaning_oso_account>> to reset your OpenShift Online and {osio} accounts.

--- a/docs/topics/modules/reviewing_detailed_resource_information.adoc
+++ b/docs/topics/modules/reviewing_detailed_resource_information.adoc
@@ -6,7 +6,7 @@
 ifeval::["{context}" == "optimizing_memory_usage"]
 The memory allowances for each OpenShift pod is 512{nbsp}MiB. As a result, each application consumes nearly 1{nbsp}GiB of memory for the *Stage* and *Run* environments.
 
-To check the your resource information details in OpenShift:
+To check your resource information details in OpenShift:
 endif::[]
 
 // for user-guide
@@ -23,7 +23,7 @@ ifeval::["{context}" == "optimizing_memory_usage"]
 image::select_project_run.png[Select the Run Project]
 +
 See <<viewing_projects_oso>> for details about the listed projects
-endif::[
+endif::[]
 
 // for user-guide
 ifeval::["{context}" == "user-guide"]

--- a/docs/topics/modules/reviewing_detailed_resource_information.adoc
+++ b/docs/topics/modules/reviewing_detailed_resource_information.adoc
@@ -1,20 +1,36 @@
-[id="reviewing_detailed_resource_information"]
+[id="reviewing_detailed_resource_information-{context}"]
 
 = Reviewing detailed resource information in OpenShift Online
 
-An additional way to review the detailed resource information for your {osio} account is to review the details in OpenShift Online.
-
+// for GSG
+ifeval::["{context}" == "optimizing_memory_usage"]
 The memory allowances for each OpenShift pod is 512{nbsp}MiB. As a result, each application consumes nearly 1{nbsp}GiB of memory for the *Stage* and *Run* environments.
 
-To check the memory limit in OpenShift Online user interface:
+To check the your resource information details in OpenShift:
+endif::[]
+
+// for user-guide
+ifeval::["{context}" == "user-guide"]
+After creating or adding a project to {osio}, you can see more detailed resource usage in OpenShift Online as follows:
+endif::[]
 
 . In a new browser tab, navigate to the OpenShift Online console at link:https://console.starter-us-east-2.openshift.com/[console.starter-us-east-2.openshift.com].
 
+// for GSG
+ifeval::["{context}" == "optimizing_memory_usage"]
 . From the list of projects at the right side of the page, click *_username_-run* to see the resources used for the *Run* environment or *_username_-stage* to see the resources for the *Stage* environment.
 +
 image::select_project_run.png[Select the Run Project]
 +
-See <<viewing_projects_oso>> for details about the listed projects.
+See <<viewing_projects_oso>> for details about the listed projects
+endif::[
+
+// for user-guide
+ifeval::["{context}" == "user-guide"]
+. From the list of projects at the right side of the page, click *_username_-run* to see the resources used for the *Run* environment or *_username_-stage* to see the resources for the *Stage* environment.
++
+image::select_project_run.png[Select the Run Project]
+endif::[]
 
 . Click btn:[Applications] and then select *Pods* in the displayed submenu.
 +
@@ -28,4 +44,9 @@ image::hw_pod.png[Hello World Project Pod]
 +
 image::resources.png[Resources]
 +
-Use this page to review the memory usage for your {osio} project. Save the details to compare after following the steps in <<reducing_project_memory_usage-{context}>>.
+Use this page to review the memory usage for your {osio} project. 
+
+// for GSG
+ifeval::["{context}" == "optimizing_memory_usage"]
+Save the details to compare after following the steps in <<reducing_project_memory_usage-{context}>>.
+endif::[]

--- a/docs/topics/modules/reviewing_detailed_resource_information.adoc
+++ b/docs/topics/modules/reviewing_detailed_resource_information.adoc
@@ -1,4 +1,5 @@
-[id="reviewing_resource_information_gui"]
+[id="reviewing_detailed_resource_information"]
+
 = Reviewing detailed resource information in OpenShift Online
 
 An additional way to review the detailed resource information for your {osio} account is to review the details in OpenShift Online.
@@ -27,4 +28,4 @@ image::hw_pod.png[Hello World Project Pod]
 +
 image::resources.png[Resources]
 +
-Use this page to review the memory usage for your {osio} project. Save the details to compare after following the steps in <<reducing_project_memory_usage>>.
+Use this page to review the memory usage for your {osio} project. Save the details to compare after following the steps in <<reducing_project_memory_usage-{context}>>.

--- a/docs/topics/modules/reviewing_resource_information_gui.adoc
+++ b/docs/topics/modules/reviewing_resource_information_gui.adoc
@@ -1,5 +1,7 @@
 [id="reviewing_resource_information_gui"]
-= Reviewing the resource information in OpenShift Online
+= Reviewing detailed resource information in OpenShift Online
+
+An additional way to review the detailed resource information for your {osio} account is to review the details in OpenShift Online.
 
 The memory allowances for each OpenShift pod is 512{nbsp}MiB. As a result, each application consumes nearly 1{nbsp}GiB of memory for the *Stage* and *Run* environments.
 
@@ -25,4 +27,4 @@ image::hw_pod.png[Hello World Project Pod]
 +
 image::resources.png[Resources]
 +
-Use this page to review the memory usage for your {osio} project.
+Use this page to review the memory usage for your {osio} project. Save the details to compare after following the steps in <<reducing_project_memory_usage>>.

--- a/docs/topics/modules/viewing_resource_usage.adoc
+++ b/docs/topics/modules/viewing_resource_usage.adoc
@@ -1,7 +1,7 @@
 [id=viewing_resource_usage]
 = Viewing resource usage
 
-An {osio} account with OpenShift Online provides two pods for your projects. To view how much of these resources are currently used in {osio}, navigate to the *Resources* page as follows:
+An {osio} account with OpenShift Online provides two pods for your projects. To view how many of these resources are currently used in {osio}, navigate to the *Resources* page as follows:
 
 . Click your username in the upper right corner of the {osio} page and click *Settings*.
 +

--- a/docs/topics/optimizing_memory_usage.adoc
+++ b/docs/topics/optimizing_memory_usage.adoc
@@ -3,17 +3,11 @@
 
 :context: optimizing_memory_usage
 
-After creating your first quickstart project, you need to optimize the application's memory usage. You can either:
+After creating your first quickstart project, you will now learn to optimize your memory usage in {osio} using the following steps:
 
-* See a high level overview of the resources used in {osio}. See <<viewing_resource_usage>>.
-
-* See the detailed memory and other usage information using OpenShift Online:
-  1. Review your current memory usage. See <<reviewing_detailed_resource_information>>.
-  2. Edit your project code to reduce your project's memory usages and commit the changes. See <<reducing_project_memory_usage-{context}>> and <<committing_pushing_changes_git-{context}>>
-  3. Compare the memory usage after the changed code builds. See <<monitoring_your_oso_quota_usage>>.
-
-
-include::modules/viewing_resource_usage.adoc[leveloffset=+1]
+1. Review the resource usage details for your project.
+2. Reduce your quickstart project's memory usage and commit the changes.
+3. Compare the change in your OpenShift Online memory quota usage.
 
 include::modules/reviewing_detailed_resource_information.adoc[leveloffset=+1]
 

--- a/docs/topics/optimizing_memory_usage.adoc
+++ b/docs/topics/optimizing_memory_usage.adoc
@@ -1,11 +1,16 @@
 [id="optimizing_memory_usage"]
 = Optimizing your memory usage
 
-After creating your first quickstart project, you will now learn to optimize your memory usage in {osio}. First, you will learn how to review your resource usage, then how to reduce your quickstart project's memory usage. Lastly, you will learn how to monitor your OpenShift Online memory quota usage.
+After creating your first quickstart project, you need to optimize the application's memory usage. You can either:
+
+* See an overview of the pods used in {osio}. See <<viewing_resource_usage>> for instructions.
+* See the detailed memory and other usage information using OpenShift Online
 
 :context: optimizing_memory_usage
 
 include::modules/viewing_resource_usage.adoc[leveloffset=+1]
+
+include::modules/reviewing_resource_information_gui.adoc[leveloffset=+1]
 
 include::modules/reducing_project_memory_usage.adoc[leveloffset=+1]
 

--- a/docs/topics/optimizing_memory_usage.adoc
+++ b/docs/topics/optimizing_memory_usage.adoc
@@ -1,19 +1,25 @@
 [id="optimizing_memory_usage"]
 = Optimizing your memory usage
 
+:context: optimizing_memory_usage
+
 After creating your first quickstart project, you need to optimize the application's memory usage. You can either:
 
-* See an overview of the pods used in {osio}. See <<viewing_resource_usage>> for instructions.
-* See the detailed memory and other usage information using OpenShift Online
+* See a high level overview of the resources used in {osio}. See <<viewing_resource_usage>>.
 
-:context: optimizing_memory_usage
+* See the detailed memory and other usage information using OpenShift Online:
+  1. Review your current memory usage. See <<reviewing_detailed_resource_information>>.
+  2. Edit your project code to reduce your project's memory usages and commit the changes. See <<reducing_project_memory_usage-{context}>> and <<committing_pushing_changes_git-{context}>>
+  3. Compare the memory usage after the changed code builds. See <<monitoring_your_oso_quota_usage>>.
+
 
 include::modules/viewing_resource_usage.adoc[leveloffset=+1]
 
-include::modules/reviewing_resource_information_gui.adoc[leveloffset=+1]
+include::modules/reviewing_detailed_resource_information.adoc[leveloffset=+1]
 
 include::modules/reducing_project_memory_usage.adoc[leveloffset=+1]
 
 include::modules/committing_pushing_changes_git.adoc[leveloffset=+1]
 
 include::modules/monitoring_your_oso_quota_usage.adoc[leveloffset=+1]
+


### PR DESCRIPTION
Restructured content to make a bit more sense in the workflow, although it still offers two paths instead of one.

Two paths are now:
1. use the OSIO resource page to see a high level summary of resource usage (just pods and memory)
2. use OSO to see the details of your usage, which is more relevant for the steps listed because it shows a clear reduction in memory usage, which can't be seen in the OSIO resources page because the change is in MiB and the resource page displays GiB.