### PR TITLE
Removes steps Re. closing planner task and iteration from various mod…

### DIFF
--- a/docs/topics/getting-started-guide.adoc
+++ b/docs/topics/getting-started-guide.adoc
@@ -13,6 +13,8 @@ include::modules/introduction_to_homescreen.adoc[leveloffset=+1]
 
 include::hello_world_developers.adoc[leveloffset=+1]
 
+include::modules/planning_your_work.adoc[leveloffset=+1]
+
 include::optimizing_memory_usage.adoc[leveloffset=+1]
 
 include::analyzing-your-application.adoc[leveloffset=+1]

--- a/docs/topics/hello_world_developers.adoc
+++ b/docs/topics/hello_world_developers.adoc
@@ -5,8 +5,6 @@
 
 include::modules/creating_new_space.adoc[leveloffset=+1]
 
-include::modules/planning_development_work.adoc[leveloffset=+1]
-
 include::modules/about_application_codebases.adoc[leveloffset=+1]
 
 include::modules/creating_new_application.adoc[leveloffset=+1]

--- a/docs/topics/modules/approving_build_pipeline.adoc
+++ b/docs/topics/modules/approving_build_pipeline.adoc
@@ -41,5 +41,3 @@ image::build1.png[Build #1 link]
 . When the *Pipeline* view indicates that the project is available in the _Run_ environment, click the icon (image:rollout_icon.png[title="Rollout"]) next to *Rollout to Run* to view the project in a new tab and test the application.
 +
 image::rollout_to_run.png[Rollout to Run]
-+
-. You have now completed the task, *Test the application in Stage and approve to the Run environment*, in the *Test Iteration*. Ensure that you change the state of the work item to *Closed* using the *Plan* tab.

--- a/docs/topics/modules/committing_pushing_changes_git.adoc
+++ b/docs/topics/modules/committing_pushing_changes_git.adoc
@@ -33,8 +33,3 @@ When the commit succeeds, the following message displays:
 image::pushed_to_origin.png[Pushed to origin]
 
 You have now committed your code changes to GitHub.
-
-//for hello world
-ifeval::["{context}" == "hello-world"]
-You have now completed the task, *Modify the quickstart codebase*, in the *Test Iteration*. Change the state of the work item to *Closed* using the *Plan* tab.
-endif::[]

--- a/docs/topics/modules/next_steps.adoc
+++ b/docs/topics/modules/next_steps.adoc
@@ -7,7 +7,7 @@ If you followed the instructions in this document, you have now learned about {o
 * Add code from an existing project to your space. See <<importing-existing-project>>.
 * Create new projects using the quickstart wizards and test them. See <<hello_world_developers>> for a Vert.X project.
 //and <<spring_boot_quickstart_tutorial>> for a Spring Boot project.
-* Plan your development work by creating work items and execute them using iterative development cycles. See <<planning_development_work>>.
+* Plan your work by creating work items and execute them using iterative development cycles. See <<planning_your_work>>.
 * Use the build pipelines to stage reviews in the *Stage* and *Run* environments. See <<working_with_pipelines>>.
 * Create Che workspaces to edit your project code and commit the changes to GitHub. See <<creating_che_workspace-hello-world>> and <<committing_pushing_changes_git-hello-world>>.
 * Optimize the memory usage for your projects to use your OpenShift Online resources more efficiently. See <<optimizing_memory_usage>>.

--- a/docs/topics/modules/planning_your_work.adoc
+++ b/docs/topics/modules/planning_your_work.adoc
@@ -1,7 +1,7 @@
-[id="planning_development_work"]
-= Planning your development work
+[id="planning_your_work"]
+= Planning your work
 
-{osio} planner provides a set of predefined templates based on common development methodologies such as Agile and Scenario Driven Development.
+{osio} planner provides a set of predefined templates based on common development methodologies such as Agile and Scenario Driven Development to track tasks as work items.
 
 Use the Agile development process to plan and execute your project using iterative cycles as follows:
 

--- a/docs/topics/modules/reviewing_publishing_changes.adoc
+++ b/docs/topics/modules/reviewing_publishing_changes.adoc
@@ -44,17 +44,13 @@ image::updated_app.png[Updated applications]
 +
 //for hello world
 ifeval::["{context}" == "hello-world"]
-. You have now completed the task, *Review and publish changes to your codebase*, in the *Test Iteration*. Ensure that you change the state of the work item to *Closed* using the *Plan* tab.
-
-. Also, close the feature *User should be able to easily launch a sample Vert.x application using a smooth developer work-flow* now that all its child tasks have been completed.
-
-Well done! You have now created your first quickstart project in {osio}, used the planner to track and execute your work, made changes to your project code, committed the changes to GitHub, and published the new version of your project.
+You have now created your first quickstart project in {osio}, made changes to your project code, committed the changes to GitHub, and published the new version of your project.
 endif::[]
 
 
 //for importing existing
 ifeval::["{context}" == "importing-existing-project"]
-Well done! You have now imported an existing project into {osio}, used a work item to track your work, made changes to your project code, committed the changes to GitHub, and published the new version of your project.
+You have now imported an existing project into {osio}, made changes to your project code, committed the changes to GitHub, and published the new version of your project.
 endif::[]
 
 

--- a/docs/topics/modules/using_stack_reports_to_analyze_your_application.adoc
+++ b/docs/topics/modules/using_stack_reports_to_analyze_your_application.adoc
@@ -25,7 +25,3 @@ For further information about the stack report, see link:user-guide.html#interpr
 . In the *Companion Dependency Details* section, click *Create work item* to add an auto-populated work item to the planner.
 +
 You have now learned how the stack report provides detailed information about your stack and its dependencies, and how it suggests alternate and additional dependencies you can add to your stack to improve your application and make it more secure.
-
-. You have now completed the task, *Use analytics to identify and resolve security and license issues in the application*,  in the *Test Iteration*. Navigate to the *Plan* tab and ensure that you change the state of the work item and its parent feature to *Closed*.
-
-. Also, close the *Test Iteration* using the options (image:kabob.png[title="Options"]) icon next to the iteration as you have now completed all the work items associated with your active iteration.

--- a/docs/topics/modules/viewing_your_detailed_oso_quota_usage.adoc
+++ b/docs/topics/modules/viewing_your_detailed_oso_quota_usage.adoc
@@ -14,3 +14,5 @@ image::optimize_memory.png[Optimizing Hello World Memory Usage]
 You can now compare these details to the details in <<reviewing_detailed_resource_information-{context}>> to see the resource usage improvements.
 
 NOTE: If you have completed these instructions for optimizing your resources but still do not have enough OpenShift Online resources, see <<cleaning_oso_account>> to reset your OpenShift Online and {osio} accounts.
+
+. You have now completed the task, *Optimize {osio} resource usage*,  in the *Test Iteration*. Navigate to the *Plan* tab and ensure that you change the state of the work item to *Closed*.


### PR DESCRIPTION
…ules and adds the closing planner task step at the end of the optimize resource module.

This PR:
- Removes the references to Planner tasks as a follow-up to PR #408 
- It moves the module to the end of the launcher experience, just before the optimize resources section as it deals only with optimize resources task as per the minimal planner module approach. Thus fixing #388 too.