### PR TITLE
Removes all references to reset environment in all guides

### DIFF
--- a/docs/topics/getting-started-guide.adoc
+++ b/docs/topics/getting-started-guide.adoc
@@ -25,8 +25,6 @@ include::using_advanced_che_features.adoc[leveloffset=+1]
 
 include::optimizing_memory_usage.adoc[leveloffset=+1]
 
-include::modules/resetting_your_ct_account.adoc[leveloffset=+1]
-
 include::importing-existing-codebase.adoc[leveloffset=+1]
 
 include::modules/next_steps.adoc[leveloffset=+1]

--- a/docs/topics/modules/before_you_begin.adoc
+++ b/docs/topics/modules/before_you_begin.adoc
@@ -4,5 +4,5 @@
 Before you use {ct}, keep the following information in mind:
 
 * When you sign up to use {ct}, you get an OpenShift Online account with enough resources to run a basic application in the stage and run environments, set pipelines, and develop the codebase in the integrated Eclipse Che workspace.
-* Your OpenShift Online Starter account includes two pods and therefore can accommodate two workspaces in {ct}. To create additional projects, you must reset your {ct} environment using the instructions in <<resetting_your_ct_account>>.
+* Your OpenShift Online Starter account includes two pods and therefore can accommodate two workspaces in {ct}. 
 * Ensure that you use {ct} with an OpenShift Online Starter account, not an OpenShift Online Pro account.

--- a/docs/topics/modules/editing_your_profile.adoc
+++ b/docs/topics/modules/editing_your_profile.adoc
@@ -12,7 +12,7 @@ In the {ct} *Profile* view, use the following steps to change your personal sett
 image::profile_menu.png[Profile menu button]
 +
 . In the *Profile* screen, click btn:[Edit Profile] to edit your profile.
-. Use the displayed dialog box to edit your *Name*, *Email*, *Company*, and *Password*, add your personal *URL* and *Bio*, and *Reset Environment*.
+. Use the displayed dialog box to edit your *Name*, *Email*, *Company*, and *Password* and add your personal *URL* and *Bio*.
 +
 NOTE: You can opt to keep your email address private from other users in {ct} by selecting the *Private* option. The default option is *Public*.
 +

--- a/docs/topics/modules/forking_example_repository.adoc
+++ b/docs/topics/modules/forking_example_repository.adoc
@@ -1,14 +1,7 @@
 [id="forking_example_repository"]
 = Forking an example repository
 
-In addition to creating applications using quickstarts, you can import an existing project into {ct}.
-
-
-.Prerequisites
-
-Reset your {ct} environment by following instructions in link:getting-started-guide.html#resetting_your_ct_account[resetting your {ct} account].
-
-.Procedure
+In addition to creating applications using quickstarts, you can import an existing project into {ct} as follows:
 
 * You can fork any one of the sample repositories in GitHub. For this tutorial, fork and use the `vertx-eventbus` repository.
 

--- a/docs/topics/modules/introduction.adoc
+++ b/docs/topics/modules/introduction.adoc
@@ -4,6 +4,3 @@
 {rhct} is a collaborative, open-source, web-based _application life cycle management_ (ALM) solution. It provides an integrated DevOps tool-chain to plan, create, and deploy hybrid cloud services.
 
 This guide walks you through the initial set up of {ct} and highlights some of its key features and components. Use this guide to set up an application in the cloud, customize it, and then deploy a new version of it in under an hour.
-
-
-//If your {ct} environment gets into a state where it is difficult or impossible to move forward, see the <<resetting_your_ct_account>> section of this document to factory reset your {ct} (and OpenShift Online) environment.

--- a/docs/topics/modules/introduction_to_homescreen.adoc
+++ b/docs/topics/modules/introduction_to_homescreen.adoc
@@ -12,13 +12,13 @@ This part of your home screen displays the latest updates to {ct} that you need 
 ////
 
 (1) Navigate between spaces::
-The upper-left corner of {ct} displays your username. Click the drop-down to view the spaces you are associated with and to navigate between them. Generally, a space is the first thing you will create when using {ct}. See link:user-guide.html#about_spaces[about spaces] to learn about spaces.
+The upper-left corner of {ct} displays your username. Click the drop-down to view the spaces you are associated with and to navigate between them. A space is the first thing you create when using {ct}. See link:user-guide.html#about_spaces[about spaces] to learn about spaces.
 
 (2) Profile and Settings::
 The upper-right corner of {ct} displays your name. Click the drop-down to view *Settings* and *Profile* options. Use these options to link:user-guide.html#changing_user_preferences[change your profile and setting preferences]. Use the *Chat with us* option to discuss any issues you face with {ct} on the MatterMost channel.
 
 (3) Recent Spaces::
-The *Recent Spaces* area of the home screen displays all the spaces you have created. When you first use {ct} or reset the environment, this space is empty and you can click btn:[Create a Space] to quickly create a new space.
+The *Recent Spaces* area of the home screen displays all the spaces you have created. When you first use {ct} this space is empty and you can click btn:[Create a Space] to quickly create a new space.
 
 (4) Recent Workspaces::
 The *Recent Workspaces* area displays all created workspaces. See <<about_workspaces, about workspaces>> to learn more about workspaces and what you can do with them.

--- a/docs/topics/modules/next_steps.adoc
+++ b/docs/topics/modules/next_steps.adoc
@@ -14,6 +14,5 @@ If you followed the instructions in this document, you have now learned about {c
 // and <<reducing_project_memory_usage-spring-boot>>.
 * Use stack reports to make improvements to your code. See <<using_stack_reports_to_analyze_your_application>>.
 * Debug your code using the Che workspace. See <<debugging_using_che_workspace>>.
-* Clean up your {ct} account so you can start afresh. See <<resetting_your_ct_account>>.
 
 You can now try using what you have learned about {ct} with your own projects. See the link:user-guide.html[{ct} User Guide] for comprehensive information about {ct} and its features. If you have any questions or suggestions for improvement with {ct} or this document, let us know using one of the methods listed in <<getting_help_and_giving_feedback>>.

--- a/docs/topics/modules/viewing_resource_usage.adoc
+++ b/docs/topics/modules/viewing_resource_usage.adoc
@@ -13,4 +13,4 @@ See <<reviewing_detailed_resource_information-user-guide>> to view further detai
 
 After you create two projects, the two pods allocated to your {oso} account are used up.
 
-NOTE: Future builds may fail if the required resources are not available. See <<resetting_your_ct_account, resetting your environment>> to reclaim all these resources.
+NOTE: Future builds may fail if the required resources are not available. 

--- a/docs/topics/modules/viewing_your_detailed_oso_quota_usage.adoc
+++ b/docs/topics/modules/viewing_your_detailed_oso_quota_usage.adoc
@@ -12,7 +12,4 @@ image::optimize_memory.png[Optimizing Hello World Memory Usage]
 . link:getting-started-guide.html#approving_your_application[Promote the application] to the *Run* environment.
 +
 You can now compare these details to the details in <<reviewing_detailed_resource_information-{context}>> to see the resource usage improvements.
-+
-NOTE: If you have completed these instructions for optimizing your resources but still do not have enough OpenShift Online resources, see <<resetting_your_ct_account>> to reset your OpenShift Online and {ct} accounts.
-
 . You have now completed the task, *Optimize {ct} resource usage*,  in the *Test Iteration*. Navigate to the *Plan* tab and ensure that you change the state of the work item to *Closed*.

--- a/docs/topics/optimizing_ct_resources.adoc
+++ b/docs/topics/optimizing_ct_resources.adoc
@@ -16,5 +16,3 @@ include::modules/reducing_project_memory_usage.adoc[leveloffset=+1]
 include::modules/committing_pushing_changes_git.adoc[leveloffset=+1]
 
 include::modules/viewing_your_detailed_oso_quota_usage.adoc[leveloffset=+1]
-
-include::modules/resetting_your_ct_account.adoc[leveloffset=+1]

--- a/docs/topics/troubleshooting.adoc
+++ b/docs/topics/troubleshooting.adoc
@@ -14,5 +14,3 @@ include::modules/pipeline_build_fail.adoc[leveloffset=+1]
 include::modules/create_run_command_macro.adoc[leveloffset=+1]
 
 include::modules/ct_frozen_chrome.adoc[leveloffset=+1]
-
-include::modules/clear_failed_builds.adoc[leveloffset=+1]

--- a/docs/topics/working_with_ct_resources.adoc
+++ b/docs/topics/working_with_ct_resources.adoc
@@ -4,5 +4,3 @@
 include::modules/viewing_resource_usage.adoc[leveloffset=+1]
 
 include::modules/reviewing_detailed_resource_information.adoc[leveloffset=+1]
-
-include::modules/resetting_your_ct_account.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR removes all references to the reset environment feature in all the guides, comprehensive and action guides.
It also removes a troubleshooting module 'clearing failed builds' as the only solution for it was to reset environment.